### PR TITLE
Basic Travis Ci setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: bionic
 
 before_install:
   - sudo apt-get install qt5-default libboost-all-dev


### PR DESCRIPTION
Add a basic travis ci config that executes cmake and builds the project.

NOTE: You probably have to enable travis for the project.