### PR TITLE
Refactor/improve Tree-Sitter-Wrapper

### DIFF
--- a/bench/tree_sitter.cpp
+++ b/bench/tree_sitter.cpp
@@ -19,12 +19,28 @@ end)#";
 
     {
         ts::Node root = tree.root_node();
-        ts::Node print3 = root.child(0).named_child(3).named_child(0).named_child(1);
+        ts::Node print3 = root.child(0)
+                              .value()
+                              .named_child(3)
+                              .value()
+                              .named_child(0)
+                              .value()
+                              .named_child(1)
+                              .value();
         REQUIRE(print3.text() == "print(3)");
 
-        ts::Node three =
-            root.child(0).named_child(3).named_child(0).named_child(1).named_child(1).named_child(
-                0);
+        ts::Node three = root.child(0)
+                             .value()
+                             .named_child(3)
+                             .value()
+                             .named_child(0)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(0)
+                             .value();
         REQUIRE(three.text() == "3");
     }
 
@@ -41,21 +57,38 @@ end)#";
     };
 
     BENCHMARK("navigate to print(3)") {
-        ts::Node print3 = root.child(0).named_child(3).named_child(0).named_child(1);
+        ts::Node print3 = root.child(0)
+                              .value()
+                              .named_child(3)
+                              .value()
+                              .named_child(0)
+                              .value()
+                              .named_child(1)
+                              .value();
         return print3;
     };
 
     BENCHMARK("navigate to 3") {
-        ts::Node three =
-            root.child(0).named_child(3).named_child(0).named_child(1).named_child(1).named_child(
-                0);
+        ts::Node three = root.child(0)
+                             .value()
+                             .named_child(3)
+                             .value()
+                             .named_child(0)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(0)
+                             .value();
         return three;
     };
 
-    ts::Node print3 = root.child(0).named_child(3).named_child(0).named_child(1);
+    ts::Node print3 =
+        root.child(0).value().named_child(3).value().named_child(0).value().named_child(1).value();
 
     BENCHMARK("navigate to 3 after visiting print(3)") {
-        ts::Node three = print3.named_child(1).named_child(0);
+        ts::Node three = print3.named_child(1).value().named_child(0).value();
         return three;
     };
 }
@@ -94,7 +127,7 @@ end)#";
         REQUIRE(three.text() == "3");
     }
 
-    BENCHMARK("create ursor") { return ts::Cursor(tree); };
+    BENCHMARK("create cursor") { return ts::Cursor(tree); };
 
     {
         ts::Cursor cursor = ts::Cursor(tree);
@@ -190,12 +223,28 @@ end)#";
         auto matches = cursor.matches();
         INFO(matches);
         // FAIL();
-        ts::Node print3 = root.child(0).named_child(3).named_child(0).named_child(1);
+        ts::Node print3 = root.child(0)
+                              .value()
+                              .named_child(3)
+                              .value()
+                              .named_child(0)
+                              .value()
+                              .named_child(1)
+                              .value();
         REQUIRE(print3.text() == "print(3)");
 
-        ts::Node three =
-            root.child(0).named_child(3).named_child(0).named_child(1).named_child(1).named_child(
-                0);
+        ts::Node three = root.child(0)
+                             .value()
+                             .named_child(3)
+                             .value()
+                             .named_child(0)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(1)
+                             .value()
+                             .named_child(0)
+                             .value();
         REQUIRE(three.text() == "3");
     }
 

--- a/include/tree_sitter/tree_sitter.hpp
+++ b/include/tree_sitter/tree_sitter.hpp
@@ -647,9 +647,9 @@ public:
      *
      * This takes the source code by copy (or move) and stores it in the tree.
      */
-    Tree parse_string(std::string);
+    Tree parse_string(std::string) const;
 
-    Tree parse_string(const TSTree* old_tree, std::string source);
+    Tree parse_string(const TSTree* old_tree, std::string source) const;
 };
 
 /**
@@ -703,12 +703,12 @@ class Tree {
     std::string source_;
 
     // not owned pointer
-    Parser* parser;
+    const Parser* parser_;
 
 public:
     // explicit because this class handles the pointer as a ressource
     // automatic conversion from pointer to this type is dangerous
-    explicit Tree(TSTree* tree, std::string source, Parser& parser);
+    explicit Tree(TSTree* tree, std::string source, const Parser& parser);
 
     // TSTree* can be safely (and fast) copied using ts_tree_copy
     Tree(const Tree&);
@@ -733,6 +733,11 @@ public:
      * Get a reference to the source code.
      */
     [[nodiscard]] const std::string& source() const;
+
+    /**
+     * Get a reference to the used parser.
+     */
+    [[nodiscard]] const Parser& parser() const;
 
     /**
      * The returned node is only valid as long as this tree is not destructed.
@@ -773,6 +778,8 @@ public:
      */
     void print_dot_graph(std::string_view file) const;
 };
+
+EditResult edit_tree(std::vector<Edit> edits, Tree& tree, TSTree* old_tree);
 
 /**
  * Allows more efficient walking of a 'Tree' than with the methods on 'Node'.

--- a/include/tree_sitter/tree_sitter.hpp
+++ b/include/tree_sitter/tree_sitter.hpp
@@ -379,7 +379,7 @@ class Node {
 public:
     struct unsafe_t {};
     // used as a token for the unsafe constructor
-    const static unsafe_t unsafe;
+    constexpr static unsafe_t unsafe{};
 
     /**
      * Creates a new node from the given tree-sitter node and the tree.

--- a/src/tree_sitter/edit_helper.cpp
+++ b/src/tree_sitter/edit_helper.cpp
@@ -1,0 +1,221 @@
+#include "tree_sitter/tree_sitter.hpp"
+#include <algorithm>
+
+namespace ts {
+// helper functions for Tree::edit
+namespace {
+// helper function to apply one edit to the tree and source code
+static AppliedEdit _apply_edit(const Edit& edit, TSTree* tree, std::string& source) {
+    const long old_size = edit.range.end.byte - edit.range.start.byte;
+
+    const std::string old_source = source.substr(edit.range.start.byte, old_size);
+
+    source.replace(edit.range.start.byte, old_size, edit.replacement);
+
+    const long end_byte_diff = static_cast<long>(edit.replacement.size()) - old_size;
+
+    const Range before = edit.range;
+    const auto column = static_cast<std::uint32_t>(before.end.point.column + end_byte_diff);
+    const auto byte = static_cast<std::uint32_t>(before.end.byte + end_byte_diff);
+    const Range after{
+        .start = edit.range.start,
+        .end = {
+            .point = {.row = edit.range.end.point.row, .column = column},
+            .byte = byte,
+        }};
+
+    const TSInputEdit input_edit{
+        .start_byte = before.start.byte,
+        .old_end_byte = before.end.byte,
+        .new_end_byte = after.end.byte,
+        .start_point =
+            TSPoint{
+                .row = before.start.point.row,
+                .column = before.start.point.column,
+            },
+        .old_end_point =
+            TSPoint{
+                .row = before.end.point.row,
+                .column = before.end.point.column,
+            },
+        .new_end_point =
+            TSPoint{
+                .row = after.end.point.row,
+                .column = after.end.point.column,
+            },
+    };
+
+    ts_tree_edit(tree, &input_edit);
+
+    return AppliedEdit{
+        .before = before,
+        .after = after,
+        .old_source = old_source,
+        .replacement = edit.replacement,
+    };
+}
+
+static inline Point _point(const TSPoint& point) {
+    return Point{
+        .row = point.row,
+        .column = point.column,
+    };
+}
+
+static inline Location _location(const TSPoint& point, const std::uint32_t byte) {
+    return Location{
+        .point = _point(point),
+        .byte = byte,
+    };
+}
+
+static inline Range _range(const TSRange& range) {
+    return Range{
+        .start = _location(range.start_point, range.start_byte),
+        .end = _location(range.end_point, range.end_byte),
+    };
+}
+
+static std::vector<Range> _get_changed_ranges(const TSTree* old_tree, const TSTree* new_tree) {
+    // this will always be set by ts_tree_get_changed_ranges
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    std::uint32_t length;
+
+    const std::unique_ptr<TSRange, decltype(&free)> ranges{
+        ts_tree_get_changed_ranges(old_tree, new_tree, &length), free};
+
+    if (length == 0) {
+        return {};
+    }
+
+    const TSRange* begin = ranges.get();
+    // we have no other choise because we get the point + length from a c api
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const TSRange* end = begin + static_cast<std::size_t>(length);
+
+    std::vector<Range> changed_ranges{length};
+
+    std::transform(
+        begin, end, changed_ranges.begin(), [](const TSRange& range) { return _range(range); });
+
+    return changed_ranges;
+}
+
+static inline void _forbid_zero_sized_edit(const Edit& edit) {
+    if (edit.range.start == edit.range.end) {
+        throw ZeroSizedEditException();
+    }
+}
+static inline void _forbid_multiline_edit(const Edit& edit) {
+    if (edit.range.start.point.row != edit.range.end.point.row ||
+        edit.replacement.find('\n') != std::string::npos) {
+        throw MultilineEditException();
+    }
+}
+
+static inline void _check_edits(const std::vector<Edit>& edits) {
+    // NOTE: assumes that the ranges are already sorted by edit.range.start.byte
+
+    for (int i = 0; i < edits.size(); ++i) {
+        const auto& edit1 = edits[i];
+
+        _forbid_zero_sized_edit(edit1);
+        _forbid_multiline_edit(edit1);
+
+        // forbid overlapping edits
+        for (int j = 0; j < edits.size(); ++j) {
+            if (i == j) {
+                continue;
+            }
+
+            const auto& edit2 = edits[j];
+
+            if (edit1.range.overlaps(edit2.range)) {
+                throw OverlappingEditException();
+            }
+        }
+    }
+}
+
+struct Adjustment {
+    Point last_point;
+    int last_width_change;
+    int cumulative_byte_change;
+};
+static inline void _adjust_edit(Edit& edit, const Adjustment& adjustment) {
+    // if the last edit was in the current line we need to adjust the
+    // location of the next edit
+    if (adjustment.last_width_change != 0 &&
+        adjustment.last_point.row == edit.range.start.point.row) {
+        edit.range.start.point.column += adjustment.last_width_change;
+        edit.range.end.point.column += adjustment.last_width_change;
+    }
+
+    edit.range.start.byte += adjustment.cumulative_byte_change;
+    edit.range.end.byte += adjustment.cumulative_byte_change;
+}
+static inline void _update_adjustment(
+    Adjustment& adjustment, const AppliedEdit& applied_edit, const Point last_point) {
+    const int before_width =
+        applied_edit.before.end.point.column - applied_edit.before.start.point.column;
+    const int after_width =
+        applied_edit.after.end.point.column - applied_edit.after.start.point.column;
+    adjustment.last_width_change = after_width - before_width;
+
+    const int byte_change = applied_edit.after.end.byte - applied_edit.before.end.byte;
+    adjustment.cumulative_byte_change += byte_change;
+    adjustment.last_point = last_point;
+}
+
+static inline std::vector<AppliedEdit>
+_apply_all_edits(std::vector<Edit>& edits, std::string& new_source, TSTree* old_tree) {
+    std::vector<AppliedEdit> applied_edits;
+    applied_edits.reserve(edits.size());
+
+    Adjustment adjustment{};
+
+    for (auto& edit : edits) {
+        const Range range_before_adjustments = edit.range;
+        _adjust_edit(edit, adjustment);
+
+        AppliedEdit applied_edit = _apply_edit(edit, old_tree, new_source);
+        applied_edit.before = range_before_adjustments;
+        applied_edits.push_back(applied_edit);
+
+        _update_adjustment(adjustment, applied_edit, edit.range.end.point);
+    }
+
+    return applied_edits;
+}
+} // namespace
+
+EditResult edit_tree(std::vector<Edit> edits, Tree& tree, TSTree* old_tree) {
+    std::string new_source = tree.source();
+
+    // sorts the edits from the earliest in the source code to the latest in the source code.
+    // this is done so the locations for edits in the same line can be adjusted
+    // so we can return the ranges of the edit before and after
+    std::sort(edits.begin(), edits.end(), [](const Edit& edit1, const Edit& edit2) {
+        return edit1.range.start.byte <= edit2.range.start.byte;
+    });
+
+    // NOTE: this throws exceptions if there is something wrong with the edits
+    _check_edits(edits);
+
+    std::vector<AppliedEdit> applied_edits = _apply_all_edits(edits, new_source, old_tree);
+
+    // reparse the source code
+    Tree new_tree = tree.parser().parse_string(old_tree, std::move(new_source));
+
+    std::vector<Range> changed_ranges = _get_changed_ranges(old_tree, new_tree.raw());
+
+    // update this tree
+    swap(tree, new_tree);
+
+    return EditResult{
+        .changed_ranges = changed_ranges,
+        .applied_edits = applied_edits,
+    };
+}
+
+} // namespace ts

--- a/src/tree_sitter/tree_sitter.cpp
+++ b/src/tree_sitter/tree_sitter.cpp
@@ -376,12 +376,12 @@ std::ostream& operator<<(std::ostream& o, const EditResult& self) {
 }
 
 // class Tree
-Tree::Tree(TSTree* tree, std::string source, Parser& parser)
-    : tree(tree, ts_tree_delete), source_(std::move(source)), parser(&parser) {}
+Tree::Tree(TSTree* tree, std::string source, const Parser& parser)
+    : tree(tree, ts_tree_delete), source_(std::move(source)), parser_(&parser) {}
 
 Tree::Tree(const Tree& other)
     : tree(ts_tree_copy(other.raw()), ts_tree_delete), source_(other.source()),
-      parser(other.parser) {}
+      parser_(other.parser_) {}
 Tree& Tree::operator=(const Tree& other) {
     Tree copy{other};
     swap(copy, *this);
@@ -392,232 +392,23 @@ void swap(Tree& self, Tree& other) noexcept {
     using std::swap;
     swap(self.tree, other.tree);
     swap(self.source_, other.source_);
-    swap(self.parser, other.parser);
+    swap(self.parser_, other.parser_);
 }
 
 const TSTree* Tree::raw() const { return this->tree.get(); }
 
 const std::string& Tree::source() const { return this->source_; }
 
+const Parser& Tree::parser() const { return *this->parser_; }
+
 Node Tree::root_node() const { return Node(Node::unsafe, ts_tree_root_node(this->raw()), *this); }
 
 Language Tree::language() const { return Language(ts_tree_language(this->raw())); }
 
-// helper functions for Tree::edit
-namespace {
-// helper function to apply one edit to the tree and source code
-static AppliedEdit _apply_edit(const Edit& edit, TSTree* tree, std::string& source) {
-    const long old_size = edit.range.end.byte - edit.range.start.byte;
-
-    const std::string old_source = source.substr(edit.range.start.byte, old_size);
-
-    source.replace(edit.range.start.byte, old_size, edit.replacement);
-
-    const long end_byte_diff = static_cast<long>(edit.replacement.size()) - old_size;
-
-    const Range before = edit.range;
-    const auto column = static_cast<std::uint32_t>(before.end.point.column + end_byte_diff);
-    const auto byte = static_cast<std::uint32_t>(before.end.byte + end_byte_diff);
-    const Range after{
-        .start = edit.range.start,
-        .end = {
-            .point = {.row = edit.range.end.point.row, .column = column},
-            .byte = byte,
-        }};
-
-    const TSInputEdit input_edit{
-        .start_byte = before.start.byte,
-        .old_end_byte = before.end.byte,
-        .new_end_byte = after.end.byte,
-        .start_point =
-            TSPoint{
-                .row = before.start.point.row,
-                .column = before.start.point.column,
-            },
-        .old_end_point =
-            TSPoint{
-                .row = before.end.point.row,
-                .column = before.end.point.column,
-            },
-        .new_end_point =
-            TSPoint{
-                .row = after.end.point.row,
-                .column = after.end.point.column,
-            },
-    };
-
-    ts_tree_edit(tree, &input_edit);
-
-    return AppliedEdit{
-        .before = before,
-        .after = after,
-        .old_source = old_source,
-        .replacement = edit.replacement,
-    };
-}
-
-static inline Point _point(const TSPoint& point) {
-    return Point{
-        .row = point.row,
-        .column = point.column,
-    };
-}
-
-static inline Location _location(const TSPoint& point, const std::uint32_t byte) {
-    return Location{
-        .point = _point(point),
-        .byte = byte,
-    };
-}
-
-static inline Range _range(const TSRange& range) {
-    return Range{
-        .start = _location(range.start_point, range.start_byte),
-        .end = _location(range.end_point, range.end_byte),
-    };
-}
-
-static std::vector<Range> _get_changed_ranges(const TSTree* old_tree, const TSTree* new_tree) {
-    // this will always be set by ts_tree_get_changed_ranges
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-    std::uint32_t length;
-
-    const std::unique_ptr<TSRange, decltype(&free)> ranges{
-        ts_tree_get_changed_ranges(old_tree, new_tree, &length), free};
-
-    if (length == 0) {
-        return {};
-    }
-
-    const TSRange* begin = ranges.get();
-    // we have no other choise because we get the point + length from a c api
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    const TSRange* end = begin + static_cast<std::size_t>(length);
-
-    std::vector<Range> changed_ranges{length};
-
-    std::transform(
-        begin, end, changed_ranges.begin(), [](const TSRange& range) { return _range(range); });
-
-    return changed_ranges;
-}
-
-static inline void _forbid_zero_sized_edit(const Edit& edit) {
-    if (edit.range.start == edit.range.end) {
-        throw ZeroSizedEditException();
-    }
-}
-static inline void _forbid_multiline_edit(const Edit& edit) {
-    if (edit.range.start.point.row != edit.range.end.point.row ||
-        edit.replacement.find('\n') != std::string::npos) {
-        throw MultilineEditException();
-    }
-}
-
-static inline void _check_edits(const std::vector<Edit>& edits) {
-    // NOTE: assumes that the ranges are already sorted by edit.range.start.byte
-
-    for (int i = 0; i < edits.size(); ++i) {
-        const auto& edit1 = edits[i];
-
-        _forbid_zero_sized_edit(edit1);
-        _forbid_multiline_edit(edit1);
-
-        // forbid overlapping edits
-        for (int j = 0; j < edits.size(); ++j) {
-            if (i == j) {
-                continue;
-            }
-
-            const auto& edit2 = edits[j];
-
-            if (edit1.range.overlaps(edit2.range)) {
-                throw OverlappingEditException();
-            }
-        }
-    }
-}
-
-struct Adjustment {
-    Point last_point;
-    int last_width_change;
-    int cumulative_byte_change;
-};
-static inline void _adjust_edit(Edit& edit, const Adjustment& adjustment) {
-    // if the last edit was in the current line we need to adjust the
-    // location of the next edit
-    if (adjustment.last_width_change != 0 &&
-        adjustment.last_point.row == edit.range.start.point.row) {
-        edit.range.start.point.column += adjustment.last_width_change;
-        edit.range.end.point.column += adjustment.last_width_change;
-    }
-
-    edit.range.start.byte += adjustment.cumulative_byte_change;
-    edit.range.end.byte += adjustment.cumulative_byte_change;
-}
-static inline void _update_adjustment(
-    Adjustment& adjustment, const AppliedEdit& applied_edit, const Point last_point) {
-    const int before_width =
-        applied_edit.before.end.point.column - applied_edit.before.start.point.column;
-    const int after_width =
-        applied_edit.after.end.point.column - applied_edit.after.start.point.column;
-    adjustment.last_width_change = after_width - before_width;
-
-    const int byte_change = applied_edit.after.end.byte - applied_edit.before.end.byte;
-    adjustment.cumulative_byte_change += byte_change;
-    adjustment.last_point = last_point;
-}
-
-static inline std::vector<AppliedEdit>
-_apply_all_edits(std::vector<Edit>& edits, std::string& new_source, TSTree* old_tree) {
-    std::vector<AppliedEdit> applied_edits;
-    applied_edits.reserve(edits.size());
-
-    Adjustment adjustment{};
-
-    for (auto& edit : edits) {
-        const Range range_before_adjustments = edit.range;
-        _adjust_edit(edit, adjustment);
-
-        AppliedEdit applied_edit = _apply_edit(edit, old_tree, new_source);
-        applied_edit.before = range_before_adjustments;
-        applied_edits.push_back(applied_edit);
-
-        _update_adjustment(adjustment, applied_edit, edit.range.end.point);
-    }
-
-    return applied_edits;
-}
-} // namespace
-
 EditResult Tree::edit(std::vector<Edit> edits) {
-    std::string new_source = this->source();
     const std::unique_ptr<TSTree, void (*)(TSTree*)> old_tree = std::move(this->tree);
 
-    // sorts the edits from the earliest in the source code to the latest in the source code.
-    // this is done so the locations for edits in the same line can be adjusted
-    // so we can return the ranges of the edit before and after
-    std::sort(edits.begin(), edits.end(), [](const Edit& edit1, const Edit& edit2) {
-        return edit1.range.start.byte <= edit2.range.start.byte;
-    });
-
-    // NOTE: this throws exceptions if there is something wrong with the edits
-    _check_edits(edits);
-
-    std::vector<AppliedEdit> applied_edits = _apply_all_edits(edits, new_source, old_tree.get());
-
-    // reparse the source code
-    Tree new_tree = this->parser->parse_string(old_tree.get(), std::move(new_source));
-
-    // update this tree
-    swap(*this, new_tree);
-
-    std::vector<Range> changed_ranges = _get_changed_ranges(old_tree.get(), this->raw());
-
-    return EditResult{
-        .changed_ranges = changed_ranges,
-        .applied_edits = applied_edits,
-    };
+    return edit_tree(std::move(edits), *this, old_tree.get());
 }
 
 void Tree::print_dot_graph(std::string_view file) const {
@@ -736,7 +527,7 @@ TSParser* Parser::raw() const { return this->parser.get(); }
 
 Language Parser::language() const { return Language(ts_parser_language(this->raw())); }
 
-Tree Parser::parse_string(const TSTree* old_tree, std::string source) {
+Tree Parser::parse_string(const TSTree* old_tree, std::string source) const {
     TSTree* tree = ts_parser_parse_string(this->raw(), old_tree, source.c_str(), source.length());
     if (tree == nullptr) {
         // TL;DR this should never happen
@@ -751,7 +542,7 @@ Tree Parser::parse_string(const TSTree* old_tree, std::string source) {
     }
     return Tree(tree, std::move(source), *this);
 }
-Tree Parser::parse_string(std::string str) { return parse_string(nullptr, std::move(str)); }
+Tree Parser::parse_string(std::string str) const { return parse_string(nullptr, std::move(str)); }
 
 // class Query
 static TSQuery* _make_query(std::string_view source) {

--- a/tests/tree_sitter.cpp
+++ b/tests/tree_sitter.cpp
@@ -28,7 +28,8 @@ TEST_CASE("Navigation", "[tree-sitter][!hide]") {
 
     public:
         BinaryOperation(ts::Node node)
-            : left_node(node.child(0)), right_node(node.child(2)), op_node(node.child(1)) {
+            : left_node(node.child(0).value()), right_node(node.child(2).value()),
+              op_node(node.child(1).value()) {
             if (node.type() != "binary_operation"s) {
                 throw std::runtime_error("not a binary_operation node");
             }
@@ -49,10 +50,10 @@ TEST_CASE("Navigation", "[tree-sitter][!hide]") {
     ts::Node root_node = tree.root_node();
     assert(root_node.type() == "program"s);
 
-    ts::Node child = root_node.named_child(0);
+    ts::Node child = root_node.named_child(0).value();
     // check all "root" types
     if (child.type() == "expression"s) {
-        ts::Node next_child = child.named_child(0);
+        ts::Node next_child = child.named_child(0).value();
         // check all expression types
         if (next_child.type() == "binary_operation"s) {
             BinaryOperation bin_op = BinaryOperation(next_child);
@@ -333,7 +334,8 @@ TEST_CASE("trees can be edited", "[tree-sitter]") {
         INFO("Pre edit: " << tree.root_node().as_s_expr());
 
         // check pre-condition on tree
-        ts::Node one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(one_node.type() == "number"s);
         CHECK(one_node.text() == "1"s);
 
@@ -353,7 +355,8 @@ TEST_CASE("trees can be edited", "[tree-sitter]") {
 
         CHECK(tree.source() == "15 + 2"s);
 
-        ts::Node new_one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node new_one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(new_one_node.type() == "number"s);
         INFO("Range of new 'one_node' " << new_one_node.range());
         CHECK(new_one_node.text() == "15"s);
@@ -366,10 +369,12 @@ TEST_CASE("trees can be edited", "[tree-sitter]") {
         INFO("Pre edit: " << tree.root_node().as_s_expr());
 
         // check pre-condition on tree
-        ts::Node one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(one_node.type() == "number"s);
         CHECK(one_node.text() == "1"s);
-        ts::Node two_node = tree.root_node().named_child(0).named_child(0).child(2);
+        ts::Node two_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(2).value();
         CHECK(two_node.type() == "number"s);
         CHECK(two_node.text() == "2"s);
 
@@ -395,11 +400,13 @@ TEST_CASE("trees can be edited", "[tree-sitter]") {
 
         CHECK(tree.source() == "15 + 7"s);
 
-        ts::Node new_one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node new_one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(new_one_node.type() == "number"s);
         INFO("Range of new 'one_node' " << new_one_node.range());
         CHECK(new_one_node.text() == "15"s);
-        ts::Node new_two_node = tree.root_node().named_child(0).named_child(0).child(2);
+        ts::Node new_two_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(2).value();
         CHECK(new_two_node.type() == "number"s);
         INFO("Range of new 'two_node' " << new_two_node.range());
         CHECK(new_two_node.text() == "7"s);
@@ -414,10 +421,10 @@ return a + b)#";
         INFO("Pre edit: " << tree.root_node().as_s_expr());
 
         // check pre-condition on tree
-        ts::Node one_node = tree.root_node().named_child(0).named_child(1);
+        ts::Node one_node = tree.root_node().named_child(0).value().named_child(1).value();
         CHECK(one_node.type() == "number"s);
         CHECK(one_node.text() == "1"s);
-        ts::Node two_node = tree.root_node().named_child(1).named_child(1);
+        ts::Node two_node = tree.root_node().named_child(1).value().named_child(1).value();
         CHECK(two_node.type() == "number"s);
         CHECK(two_node.text() == "2"s);
 
@@ -488,11 +495,11 @@ local b = 7
 return a + b)#";
         CHECK(tree.source() == expected);
 
-        ts::Node new_one_node = tree.root_node().named_child(0).named_child(1);
+        ts::Node new_one_node = tree.root_node().named_child(0).value().named_child(1).value();
         CHECK(new_one_node.type() == "number"s);
         INFO("Range of new 'one_node' " << new_one_node.range());
         CHECK(new_one_node.text() == "15"s);
-        ts::Node new_two_node = tree.root_node().named_child(1).named_child(1);
+        ts::Node new_two_node = tree.root_node().named_child(1).value().named_child(1).value();
         CHECK(new_two_node.type() == "number"s);
         INFO("Range of new 'two_node' " << new_two_node.range());
         CHECK(new_two_node.text() == "7"s);
@@ -502,7 +509,8 @@ return a + b)#";
         std::string source = "1 + 2";
         ts::Tree tree = parser.parse_string(source);
 
-        ts::Node one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(one_node.type() == "number"s);
         CHECK(one_node.text() == "1"s);
 
@@ -520,7 +528,8 @@ return a + b)#";
         std::string source = "11 + 2";
         ts::Tree tree = parser.parse_string(source);
 
-        ts::Node one_node = tree.root_node().named_child(0).named_child(0).child(0);
+        ts::Node one_node =
+            tree.root_node().named_child(0).value().named_child(0).value().child(0).value();
         CHECK(one_node.type() == "number"s);
         CHECK(one_node.text() == "11"s);
 
@@ -586,8 +595,10 @@ TEST_CASE("Query", "[tree-sitter]") {
     std::string source = "1 + 2";
     ts::Tree tree = parser.parse_string(source);
 
-    ts::Node one_node = tree.root_node().named_child(0).named_child(0).named_child(0);
-    ts::Node two_node = tree.root_node().named_child(0).named_child(0).named_child(1);
+    ts::Node one_node =
+        tree.root_node().named_child(0).value().named_child(0).value().named_child(0).value();
+    ts::Node two_node =
+        tree.root_node().named_child(0).value().named_child(0).value().named_child(1).value();
 
     INFO(tree.root_node());
 
@@ -700,23 +711,23 @@ TEST_CASE("Node", "[tree-sitter]") {
         REQUIRE(root.type() != nullptr);
         REQUIRE(std::strlen(root.type()) > 0);
 
-        ts::Node expr = root.named_child(0);
+        ts::Node expr = root.named_child(0).value();
         REQUIRE(expr.type() != nullptr);
         REQUIRE(std::strlen(expr.type()) > 0);
 
-        ts::Node bin_op = expr.named_child(0);
+        ts::Node bin_op = expr.named_child(0).value();
         REQUIRE(bin_op.type() != nullptr);
         REQUIRE(std::strlen(bin_op.type()) > 0);
 
-        ts::Node number_1 = bin_op.child(0);
+        ts::Node number_1 = bin_op.child(0).value();
         REQUIRE(number_1.type() != nullptr);
         REQUIRE(std::strlen(number_1.type()) > 0);
 
-        ts::Node op = bin_op.child(1);
+        ts::Node op = bin_op.child(1).value();
         REQUIRE(op.type() != nullptr);
         REQUIRE(std::strlen(op.type()) > 0);
 
-        ts::Node number_2 = bin_op.child(2);
+        ts::Node number_2 = bin_op.child(2).value();
         REQUIRE(number_2.type() != nullptr);
         REQUIRE(std::strlen(number_2.type()) > 0);
     }
@@ -724,65 +735,63 @@ TEST_CASE("Node", "[tree-sitter]") {
     SECTION("type_id() returns a non-zero type id") {
         REQUIRE(root.type_id() != 0);
 
-        ts::Node expr = root.named_child(0);
+        ts::Node expr = root.named_child(0).value();
         REQUIRE(expr.type_id() != 0);
 
-        ts::Node bin_op = expr.named_child(0);
+        ts::Node bin_op = expr.named_child(0).value();
         REQUIRE(bin_op.type() != nullptr);
 
-        ts::Node number_1 = bin_op.child(0);
+        ts::Node number_1 = bin_op.child(0).value();
         REQUIRE(number_1.type() != nullptr);
 
-        ts::Node op = bin_op.child(1);
+        ts::Node op = bin_op.child(1).value();
         REQUIRE(op.type() != nullptr);
 
-        ts::Node number_2 = bin_op.child(2);
+        ts::Node number_2 = bin_op.child(2).value();
         REQUIRE(number_2.type() != nullptr);
     }
 
     SECTION("child methods return a null node only if there are no more children") {
-        REQUIRE(!root.is_null());
+        auto expr = root.named_child(0);
+        REQUIRE(expr);
 
-        ts::Node expr = root.named_child(0);
-        REQUIRE(!expr.is_null());
+        auto bin_op = expr.value().named_child(0);
+        REQUIRE(bin_op);
 
-        ts::Node bin_op = expr.named_child(0);
-        REQUIRE(!bin_op.is_null());
+        auto number_1 = bin_op.value().child(0);
+        REQUIRE(number_1);
 
-        ts::Node number_1 = bin_op.child(0);
-        REQUIRE(!number_1.is_null());
+        auto op = bin_op.value().child(1);
+        REQUIRE(op);
 
-        ts::Node op = bin_op.child(1);
-        REQUIRE(!op.is_null());
+        auto number_2 = bin_op.value().child(2);
+        REQUIRE(number_2);
 
-        ts::Node number_2 = bin_op.child(2);
-        REQUIRE(!number_2.is_null());
-
-        REQUIRE(root.child(1).is_null());
-        REQUIRE(root.child(5).is_null());
-        REQUIRE(number_2.child(0).is_null());
+        REQUIRE(!root.child(1));
+        REQUIRE(!root.child(5));
+        REQUIRE(!number_2.value().child(0));
     }
 
     SECTION("named_child only return named nodes") {
-        ts::Node expr = root.named_child(0);
+        ts::Node expr = root.named_child(0).value();
         REQUIRE(expr.is_named());
 
-        ts::Node bin_op = expr.named_child(0);
+        ts::Node bin_op = expr.named_child(0).value();
         REQUIRE(bin_op.is_named());
 
-        ts::Node number_1 = bin_op.named_child(0);
+        ts::Node number_1 = bin_op.named_child(0).value();
         REQUIRE(number_1.is_named());
 
-        ts::Node op = bin_op.child(1);
+        ts::Node op = bin_op.child(1).value();
         REQUIRE(!op.is_named());
 
-        ts::Node number_2 = bin_op.named_child(1);
+        ts::Node number_2 = bin_op.named_child(1).value();
         REQUIRE(number_2.is_named());
     }
 
     SECTION("children returns at least as many as named_children") {
-        ts::Node expr = root.named_child(0);
-        ts::Node bin_op = expr.named_child(0);
+        ts::Node expr = root.named_child(0).value();
+        ts::Node bin_op = expr.named_child(0).value();
 
         auto children = bin_op.children();
         auto named_children = bin_op.named_children();
@@ -806,10 +815,10 @@ TEST_CASE("tree-sitter parses lua programs", "[tree-sitter][parser]") {
         INFO(root_node.as_s_expr());
         CHECK(root_node.type() == "program"s);
 
-        ts::Node expr_node = root_node.child(0);
+        ts::Node expr_node = root_node.child(0).value();
         CHECK(expr_node.type() == "expression"s);
 
-        ts::Node bin_op_node = expr_node.named_child(0);
+        ts::Node bin_op_node = expr_node.named_child(0).value();
         CHECK(bin_op_node.type() == "binary_operation"s);
         CHECK(bin_op_node.named_child_count() == 2);
         CHECK(bin_op_node.start_byte() == 0);
@@ -817,14 +826,14 @@ TEST_CASE("tree-sitter parses lua programs", "[tree-sitter][parser]") {
         CHECK(bin_op_node.start_point() == ts::Point{.row = 0, .column = 0});
         CHECK(bin_op_node.end_point() == ts::Point{.row = 0, .column = 5});
 
-        ts::Node number_1_node = bin_op_node.named_child(0);
+        ts::Node number_1_node = bin_op_node.named_child(0).value();
         CHECK(number_1_node.type() == "number"s);
         CHECK(number_1_node.start_byte() == 0);
         CHECK(number_1_node.end_byte() == 1);
         CHECK(number_1_node.start_point() == ts::Point{.row = 0, .column = 0});
         CHECK(number_1_node.end_point() == ts::Point{.row = 0, .column = 1});
 
-        ts::Node number_2_node = bin_op_node.named_child(1);
+        ts::Node number_2_node = bin_op_node.named_child(1).value();
         CHECK(number_2_node.type() == "number"s);
         CHECK(number_2_node.start_byte() == 4);
         CHECK(number_2_node.end_byte() == 5);
@@ -848,19 +857,19 @@ end
         INFO(root_node.as_s_expr());
         CHECK(root_node.type() == "program"s);
 
-        ts::Node if_stmt = root_node.child(0);
+        ts::Node if_stmt = root_node.child(0).value();
         CHECK(if_stmt.type() == "if_statement"s);
         CHECK(if_stmt.named_child_count() == 4);
 
-        ts::Node condition = if_stmt.named_child(0);
+        ts::Node condition = if_stmt.named_child(0).value();
         CHECK(condition.type() == "condition_expression"s);
         CHECK(condition.named_child_count() == 1);
 
-        ts::Node true_lit = condition.named_child(0);
+        ts::Node true_lit = condition.named_child(0).value();
         CHECK(true_lit.type() == "true"s);
 
         {
-            ts::Node call1 = if_stmt.named_child(1);
+            ts::Node call1 = if_stmt.named_child(1).value();
             CHECK(call1.type() == "function_call"s);
             CHECK(call1.start_byte() == 17);
             CHECK(call1.end_byte() == 25);
@@ -868,7 +877,7 @@ end
             CHECK(call1.end_point() == ts::Point{.row = 1, .column = 12});
             CHECK(call1.text() == "print(1)"s);
 
-            ts::Node call1_ident = call1.named_child(0);
+            ts::Node call1_ident = call1.named_child(0).value();
             CHECK(call1_ident.type() == "identifier"s);
             CHECK(call1_ident.start_byte() == 17);
             CHECK(call1_ident.end_byte() == 22);
@@ -876,11 +885,11 @@ end
             CHECK(call1_ident.end_point() == ts::Point{.row = 1, .column = 9});
             CHECK(call1_ident.text() == "print"s);
 
-            ts::Node call1_args = call1.named_child(1);
+            ts::Node call1_args = call1.named_child(1).value();
             CHECK(call1_args.type() == "arguments"s);
             CHECK(call1_args.named_child_count() == 1);
 
-            ts::Node call1_arg1 = call1_args.named_child(0);
+            ts::Node call1_arg1 = call1_args.named_child(0).value();
             CHECK(call1_arg1.type() == "number"s);
             CHECK(call1_arg1.start_byte() == 23);
             CHECK(call1_arg1.end_byte() == 24);
@@ -890,7 +899,7 @@ end
         }
 
         {
-            ts::Node call2 = if_stmt.named_child(2);
+            ts::Node call2 = if_stmt.named_child(2).value();
             CHECK(call2.type() == "function_call"s);
             CHECK(call2.start_byte() == 30);
             CHECK(call2.end_byte() == 38);
@@ -898,7 +907,7 @@ end
             CHECK(call2.end_point() == ts::Point{.row = 2, .column = 12});
             CHECK(call2.text() == "print(2)"s);
 
-            ts::Node call2_ident = call2.named_child(0);
+            ts::Node call2_ident = call2.named_child(0).value();
             CHECK(call2_ident.type() == "identifier"s);
             CHECK(call2_ident.start_byte() == 30);
             CHECK(call2_ident.end_byte() == 35);
@@ -906,11 +915,11 @@ end
             CHECK(call2_ident.end_point() == ts::Point{.row = 2, .column = 9});
             CHECK(call2_ident.text() == "print"s);
 
-            ts::Node call2_args = call2.named_child(1);
+            ts::Node call2_args = call2.named_child(1).value();
             CHECK(call2_args.type() == "arguments"s);
             CHECK(call2_args.named_child_count() == 1);
 
-            ts::Node call2_arg1 = call2_args.named_child(0);
+            ts::Node call2_arg1 = call2_args.named_child(0).value();
             CHECK(call2_arg1.type() == "number"s);
             CHECK(call2_arg1.start_byte() == 36);
             CHECK(call2_arg1.end_byte() == 37);
@@ -920,7 +929,7 @@ end
         }
 
         {
-            ts::Node else_branch = if_stmt.named_child(3);
+            ts::Node else_branch = if_stmt.named_child(3).value();
             CHECK(else_branch.type() == "else"s);
             CHECK(else_branch.start_byte() == 39);
             CHECK(else_branch.end_byte() == 69);
@@ -929,7 +938,7 @@ end
             CHECK(else_branch.named_child_count() == 2);
 
             {
-                ts::Node call3 = else_branch.named_child(0);
+                ts::Node call3 = else_branch.named_child(0).value();
                 CHECK(call3.type() == "function_call"s);
                 CHECK(call3.start_byte() == 48);
                 CHECK(call3.end_byte() == 56);
@@ -937,7 +946,7 @@ end
                 CHECK(call3.end_point() == ts::Point{.row = 4, .column = 12});
                 CHECK(call3.text() == "print(3)"s);
 
-                ts::Node call3_ident = call3.named_child(0);
+                ts::Node call3_ident = call3.named_child(0).value();
                 CHECK(call3_ident.type() == "identifier"s);
                 CHECK(call3_ident.start_byte() == 48);
                 CHECK(call3_ident.end_byte() == 53);
@@ -945,11 +954,11 @@ end
                 CHECK(call3_ident.end_point() == ts::Point{.row = 4, .column = 9});
                 CHECK(call3_ident.text() == "print"s);
 
-                ts::Node call3_args = call3.named_child(1);
+                ts::Node call3_args = call3.named_child(1).value();
                 CHECK(call3_args.type() == "arguments"s);
                 CHECK(call3_args.named_child_count() == 1);
 
-                ts::Node call3_arg1 = call3_args.named_child(0);
+                ts::Node call3_arg1 = call3_args.named_child(0).value();
                 CHECK(call3_arg1.type() == "number"s);
                 CHECK(call3_arg1.start_byte() == 54);
                 CHECK(call3_arg1.end_byte() == 55);
@@ -959,7 +968,7 @@ end
             }
 
             {
-                ts::Node call4 = else_branch.named_child(1);
+                ts::Node call4 = else_branch.named_child(1).value();
                 CHECK(call4.type() == "function_call"s);
                 CHECK(call4.start_byte() == 61);
                 CHECK(call4.end_byte() == 69);
@@ -967,7 +976,7 @@ end
                 CHECK(call4.end_point() == ts::Point{.row = 5, .column = 12});
                 CHECK(call4.text() == "print(4)"s);
 
-                ts::Node call4_ident = call4.named_child(0);
+                ts::Node call4_ident = call4.named_child(0).value();
                 CHECK(call4_ident.type() == "identifier"s);
                 CHECK(call4_ident.start_byte() == 61);
                 CHECK(call4_ident.end_byte() == 66);
@@ -975,11 +984,11 @@ end
                 CHECK(call4_ident.end_point() == ts::Point{.row = 5, .column = 9});
                 CHECK(call4_ident.text() == "print"s);
 
-                ts::Node call4_args = call4.named_child(1);
+                ts::Node call4_args = call4.named_child(1).value();
                 CHECK(call4_args.type() == "arguments"s);
                 CHECK(call4_args.named_child_count() == 1);
 
-                ts::Node call4_arg1 = call4_args.named_child(0);
+                ts::Node call4_arg1 = call4_args.named_child(0).value();
                 CHECK(call4_arg1.type() == "number"s);
                 CHECK(call4_arg1.start_byte() == 67);
                 CHECK(call4_arg1.end_byte() == 68);


### PR DESCRIPTION
Fixes #6 

- Node can no longer be null
- Refactor/simplyfy Tree-Sitter-Wrapper implementation
