### PR TITLE
Add docs generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "extern/catch2"]
 	path = extern/catch2
 	url = ../../catchorg/Catch2.git
+[submodule "extern/doxygen-dark-theme"]
+	path = extern/doxygen-dark-theme
+	url = ../../Lythenas/doxygen-dark-theme

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
       - clang-tidy-10
       - cmake
       - llvm-10
+      - doxygen
 
 env:
   global:
@@ -25,7 +26,8 @@ env:
 
 jobs:
   include:
-    - compiler: gcc
+    - stage: Test
+      compiler: gcc
       before_script: ./scripts/setup_build.sh -DCMAKE_BUILD_TYPE=Coverage
       script:
         - ./scripts/build.sh
@@ -87,3 +89,17 @@ jobs:
       before_script: ./scripts/setup_build.sh
       script: ./scripts/check_format.sh -ferror-limit=1 --dry-run
       allow_failure: true
+
+    - stage: Deploy
+      name: Docs
+      before_script: ./scripts/setup_build.sh
+      script: ./scripts/docs.sh
+      deploy:
+        provider: pages
+        skip_cleanup: true
+        github_token: $GITHUB_TOKEN
+        on:
+          branch: master
+        target_branch: gh-pages
+        local_dir: /build/docs/html
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
+# documentation
+find_package(Doxygen)
+
 # dependencies
 find_package(TreeSitter)
 find_package(TreeSitterLua)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 MiniLua is a small lua interpreter that implements additional features like source location tracking. It is currently used in and developed for the interactive_script rqt plugin.
 
+Also see: [Dokumentation](https://sp-uulm.github.io/MiniLua/)
+
 ## Building MiniLua
 
 Make sure you cloned the repository with submodules (e.g. `git clone --recurse-submodules git@github.com:sp-uulm/MiniLua.git`) or if you already cloned the repository you need to fetch the submodules (e.g. `git submodule update --init --recursive`).

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ev
+
+source "$(dirname "${BASH_SOURCE[0]}")/_env.sh"
+
+pushd build
+make MiniLua-docs $@
+popd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,13 @@ if(DOXYGEN_FOUND)
     set(DOXYGEN_TEMPLATE_RELATIONS YES)
     set(DOXYGEN_DOT_IMAGE_FORMAT svg)
     set(DOXYGEN_EXTRACT_ALL YES)
+    set(DOXYGEN_HTML_EXTRA_STYLESHEET
+        ${PROJECT_SOURCE_DIR}/extern/doxygen-dark-theme/custom.css
+        ${PROJECT_SOURCE_DIR}/extern/doxygen-dark-theme/custom_dark_theme.css)
+    set(DOXYGEN_HTML_HEADER
+        ${PROJECT_SOURCE_DIR}/extern/doxygen-dark-theme/html_header.html)
+    set(DOXYGEN_HTML_FOOTER
+        ${PROJECT_SOURCE_DIR}/extern/doxygen-dark-theme/html_footer.html)
 
     doxygen_add_docs(${PROJECT_NAME}-docs
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,3 +31,19 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
 install(EXPORT ${PROJECT_NAME}
         FILE ${PROJECT_NAME}Config.cmake
         DESTINATION lib/cmake/${PROJECT_NAME})
+
+
+# documentation
+if(DOXYGEN_FOUND)
+    set(DOXYGEN_OUTPUT_DIRECTORY ../docs)
+    set(DOXYGEN_CLANG_ASSISTED_PARSING YES)
+    set(DOXYGEN_CLANG_DATABASE_PATH .)
+    set(DOXYGEN_UML_LOOK YES)
+    set(DOXYGEN_TEMPLATE_RELATIONS YES)
+    set(DOXYGEN_DOT_IMAGE_FORMAT svg)
+    set(DOXYGEN_EXTRACT_ALL YES)
+
+    doxygen_add_docs(${PROJECT_NAME}-docs
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}/include)
+endif()


### PR DESCRIPTION
Generate docs using `./script/docs.sh`.

Open `build/docs/html/index.html` to view docs.

Closes #47 