### PR TITLE
Fixes for Ci

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           submodules: true
       - name: Setup VM
-        run: ./.github/workflows/install_packages.sh
+        run: |
+          ./.github/workflows/install_packages.sh
+          sudo apt-get install doxygen
       - name: Setup CMake
         run: ./scripts/setup_build.sh
       - name: Build Documentation

--- a/.github/workflows/minilua.yml
+++ b/.github/workflows/minilua.yml
@@ -125,6 +125,10 @@ jobs:
       CC: clang-10
       CXX: clang++-10
 
+    # the memory sanitizer produces very likely false positives
+    # when libstdc++ is not complied with it
+    continue-on-error: true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/cmake/FindSanitizers.cmake
+++ b/cmake/FindSanitizers.cmake
@@ -11,7 +11,7 @@ set(CMAKE_CXX_FLAGS_ASAN
 # detects uninitialized reads (may have false positives)
 # does not work with gcc only clang
 set(CMAKE_CXX_FLAGS_MSAN
-    "-fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fsanitize-memory-use-after-dtor -fno-omit-frame-pointer -g -O2"
+    "-fsanitize=memory -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2 -fsanitize-memory-use-after-dtor -fno-omit-frame-pointer -g -O1"
     CACHE STRING "Flags used by the C++ compiler during MemorySanitizer builds."
     FORCE)
 


### PR DESCRIPTION
- Disable memory sanitizer in CI because of many false positives
- Install Doxygen