### PR TITLE
Fix test

### DIFF
--- a/tests/stdlib_tests.cpp
+++ b/tests/stdlib_tests.cpp
@@ -52,7 +52,7 @@ TEST_CASE("to_string") {
     }
 
     SECTION("Function to String") {
-        minilua::Function f();
+        minilua::Function f{[](const minilua::CallContext&) {}};
         minilua::Vallist list = minilua::Vallist({f});
         ctx = ctx.make_new(list);
         CHECK(minilua::to_string(ctx) != minilua::Value(""));


### PR DESCRIPTION
`minilua::Function f()` declares a new function named `f` that takes no parameters and returns `minilua::Function`.