### PR TITLE
Implement length operator (`#`) correctly for tables

### DIFF
--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -344,6 +344,13 @@ public:
     auto operator=(Table&& other) noexcept -> Table&;
     friend void swap(Table& self, Table& other);
 
+    /**
+     * The result of the lua length operator `#`.
+     *
+     * Satisfies: `(border == 0 or t[border] ~= nil) and t[border + 1] == nil`
+     */
+    [[nodiscard]] auto border() const -> int;
+
     auto get(const Value& key) -> Value;
     auto has(const Value& key) -> bool;
     void set(const Value& key, Value value);

--- a/luaprograms/unit_tests/literals/table.lua
+++ b/luaprograms/unit_tests/literals/table.lua
@@ -40,3 +40,19 @@ assert(#t8 == 0)
 assert(t8[24] == 14)
 assert(t8[12.4] == 22)
 
+t9 = {22}
+assert(#t9 == 1)
+
+t10 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+assert(#t10 == 12)
+
+t11 = {1, 2, 3, 4, key = true, key2 = false}
+assert(#t11 == 4)
+
+t12 = {1, key = 2, [3] = 3}
+assert(#t12 == 1)
+
+t13 = {[1] = 1, [2] = 2, [4] = 4}
+-- both are correct according to the definition in the lua spec:
+--   (border == 0 or t[border] ~= nil) and t[border + 1] == nil
+assert(#t13 == 2 or #t13 == 4)

--- a/luaprograms/unit_tests/literals/table.lua
+++ b/luaprograms/unit_tests/literals/table.lua
@@ -5,38 +5,38 @@ t6 = {42, 43, 44}
 assert(#t6 == 3)
 
 t2 = {key = 42}
-assert(#t2 == 1)
+assert(#t2 == 0)
 assert(t2.key == 42)
 assert(t2["key"] == 42)
 
 t3 = {["key"] = 42}
-assert(#t3 == 1)
+assert(#t3 == 0)
 assert(t3.key == 42)
 assert(t3["key"] == 42)
 
 t4 = {key1 = 42, key2 = 43}
-assert(#t4 == 2)
+assert(#t4 == 0)
 assert(t4.key1 == 42)
 assert(t4["key1"] == 42)
 assert(t4.key2 == 43)
 assert(t4["key2"] == 43)
 
 t5 = {key1 = 42; key2 = 43}
-assert(#t5 == 2)
+assert(#t5 == 0)
 assert(t5.key1 == 42)
 assert(t5["key1"] == 42)
 assert(t5.key2 == 43)
 assert(t5["key2"] == 43)
 
 t7 = {key = {sub_key = 42}}
-assert(#t7 == 1)
-assert(#t7.key == 1)
-assert(#t7["key"] == 1)
+assert(#t7 == 0)
+assert(#t7.key == 0)
+assert(#t7["key"] == 0)
 assert(t7.key.sub_key ==  42)
 assert(t7["key"]["sub_key"] ==  42)
 
 t8 = {[24] = 14, [12.4] = 22}
-assert(#t8 == 2)
+assert(#t8 == 0)
 assert(t8[24] == 14)
 assert(t8[12.4] == 22)
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -20,13 +20,32 @@ auto TableImpl::calc_border() const -> int {
         return 0;
     }
 
-    // TODO this can be done in O(log N)
-    int border = 2;
-    while (has_value(border)) {
-        ++border;
+    // Binary search (slightly modified)
+    // to find the integer key where the predicate for the border is true
+    //   (border == 0 or t[border] ~= nil) and t[border + 1] == nil
+    //
+    // This does not in all cases return the same border as the official lua
+    // interpreter. But this is premitted.
+    // See: https://www.lua.org/manual/5.3/manual.html#3.4.7
+    int lower = 1;
+    int upper = this->value.size();
+
+    while (lower <= upper) {
+        int border = (upper + lower) / 2;
+
+        bool it_has = has_value(border);
+        bool next_has = has_value(border + 1);
+
+        if (it_has && next_has) {
+            lower = border + 1;
+        } else if (!it_has) {
+            upper = border - 1;
+        } else if (it_has && !next_has) {
+            return border;
+        }
     }
 
-    return border - 1;
+    throw std::runtime_error("implemented of operator # has a bug");
 }
 
 // struct Table

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -1,9 +1,33 @@
 #include "table.hpp"
 #include <MiniLua/allocator.hpp>
 
+#include <algorithm>
 #include <set>
+#include <utility>
 
 namespace minilua {
+
+// struct TableImpl
+void TableImpl::set(const Value& key, Value value) { this->value[key] = std::move(value); }
+
+auto TableImpl::calc_border() const -> int {
+    auto has_value = [this](int key) -> bool {
+        auto value = this->value.find(key);
+        return value != this->value.end() && value->second != Nil();
+    };
+
+    if (!has_value(1)) {
+        return 0;
+    }
+
+    // TODO this can be done in O(log N)
+    int border = 2;
+    while (has_value(border)) {
+        ++border;
+    }
+
+    return border - 1;
+}
 
 // struct Table
 Table::iterator::iterator() = default;
@@ -83,7 +107,7 @@ Table::Table(
 
 Table::Table(const Table& other, MemoryAllocator* allocator) : Table(allocator) {
     for (const auto& [key, value] : other) {
-        this->set(Value(key, allocator), Value(value, allocator));
+        this->impl->value.insert_or_assign(Value(key, allocator), Value(value, allocator));
     }
 }
 
@@ -105,6 +129,8 @@ void swap(Table& self, Table& other) {
     std::swap(self.impl, other.impl);
 }
 
+auto Table::border() const -> int { return this->impl->calc_border(); }
+
 auto Table::get(const Value& key) -> Value {
     auto value = impl->value.find(key);
     if (value == impl->value.end()) {
@@ -114,8 +140,8 @@ auto Table::get(const Value& key) -> Value {
     }
 }
 auto Table::has(const Value& key) -> bool { return impl->value.find(key) != impl->value.end(); }
-void Table::set(const Value& key, Value value) { impl->value[key] = std::move(value); }
-void Table::set(Value&& key, Value value) { impl->value[key] = std::move(value); }
+void Table::set(const Value& key, Value value) { impl->set(key, std::move(value)); }
+void Table::set(Value&& key, Value value) { impl->set(key, std::move(value)); }
 [[nodiscard]] auto Table::size() const -> size_t { return impl->value.size(); }
 
 auto Table::begin() -> Table::iterator {

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -9,6 +9,9 @@ namespace minilua {
 
 struct TableImpl {
     std::unordered_map<Value, Value> value;
+
+    void set(const Value& key, Value value);
+    auto calc_border() const -> int;
 };
 
 struct Table::iterator::Impl {

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -881,9 +881,7 @@ static inline auto num_op_helper(
     return std::visit(
                overloaded{
                    [](const String& value) -> Value { return (int)value.value.size(); },
-                   [](const Table& value) -> Value {
-                       return (int)std::distance(value.begin(), value.end());
-                   },
+                   [](const Table& value) -> Value { return value.border(); },
                    [](const auto& value) -> Value {
                        throw std::runtime_error(
                            "attempt to get length for value of type " + std::string(value.TYPE));


### PR DESCRIPTION
Fixes #80

See also: https://www.lua.org/manual/5.3/manual.html#3.4.7