### PR TITLE
Allow loading stdlib from a lua file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(MiniLua VERSION 1.0
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-add_compile_options(-Wall)
+add_compile_options(-Wall -Werror=return-type)
 
 # generates compile_commands.json that can be used by clang tooling
 # (e.g. language server)

--- a/bin/main.cpp
+++ b/bin/main.cpp
@@ -33,7 +33,6 @@ auto main(int argc, char* argv[]) -> int {
     }
 
     minilua::Interpreter interpreter;
-    interpreter.environment().add_default_stdlib();
     interpreter.config().all(trace);
 
     if (auto result = interpreter.parse(source_code); !result) {

--- a/include/MiniLua/environment.hpp
+++ b/include/MiniLua/environment.hpp
@@ -50,11 +50,6 @@ public:
     [[nodiscard]] auto make_table() const -> Table;
 
     /**
-     * Populates the environment with the (implemented) lua standard library.
-     */
-    void add_default_stdlib();
-
-    /**
      * Add a variable to the environment.
      */
     void add(const std::string& name, Value value);

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -156,6 +156,11 @@ public:
     auto hint() -> std::string&;
 
     /**
+     * Removes the filename from the ranges in the tree.
+     */
+    void remove_filename();
+
+    /**
      * Visit the root node of the tree of source changes.
      *
      * You have to manually navigate the tree.

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -54,19 +54,18 @@ struct Range {
      * Optional filename where the Range is located.
      *
      * The filename is behind a shared_ptr to avoid unnecessary copies.
-     *
-     * \note Changing the underlying string might lead to undefined behaviour.
      */
-    std::optional<std::shared_ptr<std::string>> file;
+    std::optional<std::shared_ptr<const std::string>> file;
 
     /**
      * Returns a copy of this range with the filename changed.
      */
-    [[nodiscard]] auto with_file(std::optional<std::shared_ptr<std::string>> file) const -> Range;
+    [[nodiscard]] auto with_file(std::optional<std::shared_ptr<const std::string>> file) const
+        -> Range;
 };
 
-auto operator==(Range lhs, Range rhs) noexcept -> bool;
-auto operator!=(Range lhs, Range rhs) noexcept -> bool;
+auto operator==(const Range& lhs, const Range& rhs) noexcept -> bool;
+auto operator!=(const Range& lhs, const Range& rhs) noexcept -> bool;
 auto operator<<(std::ostream&, const Range&) -> std::ostream&;
 
 class SourceChangeTree;

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -54,8 +54,15 @@ struct Range {
      * Optional filename where the Range is located.
      *
      * The filename is behind a shared_ptr to avoid unnecessary copies.
+     *
+     * \note Changing the underlying string might lead to undefined behaviour.
      */
     std::optional<std::shared_ptr<std::string>> file;
+
+    /**
+     * Returns a copy of this range with the filename changed.
+     */
+    [[nodiscard]] auto with_file(std::optional<std::shared_ptr<std::string>> file) const -> Range;
 };
 
 auto operator==(Range lhs, Range rhs) noexcept -> bool;

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -4,6 +4,7 @@
 #include "MiniLua/utils.hpp"
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <optional>
 #include <variant>
@@ -48,13 +49,17 @@ auto operator<<(std::ostream&, const Location&) -> std::ostream&;
 struct Range {
     Location start;
     Location end;
-    std::optional<std::string_view> file;
+
+    /**
+     * Optional filename where the Range is located.
+     *
+     * The filename is behind a shared_ptr to avoid unnecessary copies.
+     */
+    std::optional<std::shared_ptr<std::string>> file;
 };
 
-constexpr auto operator==(Range lhs, Range rhs) noexcept -> bool {
-    return lhs.start == rhs.start && lhs.end == rhs.end && lhs.file == rhs.file;
-}
-constexpr auto operator!=(Range lhs, Range rhs) noexcept -> bool { return !(lhs == rhs); }
+auto operator==(Range lhs, Range rhs) noexcept -> bool;
+auto operator!=(Range lhs, Range rhs) noexcept -> bool;
 auto operator<<(std::ostream&, const Range&) -> std::ostream&;
 
 class SourceChangeTree;

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -48,10 +48,11 @@ auto operator<<(std::ostream&, const Location&) -> std::ostream&;
 struct Range {
     Location start;
     Location end;
+    std::optional<std::string_view> file;
 };
 
 constexpr auto operator==(Range lhs, Range rhs) noexcept -> bool {
-    return lhs.start == rhs.start && lhs.end == rhs.end;
+    return lhs.start == rhs.start && lhs.end == rhs.end && lhs.file == rhs.file;
 }
 constexpr auto operator!=(Range lhs, Range rhs) noexcept -> bool { return !(lhs == rhs); }
 auto operator<<(std::ostream&, const Range&) -> std::ostream&;

--- a/include/MiniLua/stdlib.hpp
+++ b/include/MiniLua/stdlib.hpp
@@ -7,6 +7,9 @@
 #include "MiniLua/values.hpp"
 
 namespace minilua {
+
+void error(const CallContext& ctx);
+
 auto to_string(const CallContext& ctx) -> Value;
 
 auto to_number(const CallContext& ctx) -> Value;

--- a/include/MiniLua/stdlib.hpp
+++ b/include/MiniLua/stdlib.hpp
@@ -16,8 +16,6 @@ auto to_number(const CallContext& ctx) -> Value;
 
 auto type(const CallContext& ctx) -> Value;
 
-auto assert_lua(const CallContext& ctx) -> Vallist;
-
 auto next(const CallContext& ctx) -> Vallist;
 
 /**
@@ -35,6 +33,7 @@ auto next(const CallContext& ctx) -> Vallist;
 auto select(const CallContext& ctx) -> Vallist;
 
 void print(const CallContext& ctx);
+
 } // namespace minilua
 
 #endif

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -725,6 +725,11 @@ public:
     [[nodiscard]] auto is_unary() const -> bool;
 
     [[nodiscard]] auto force(const Value&) const -> std::optional<SourceChangeTree>;
+
+    /**
+     * Sets the file of the underlying origin type (if possible).
+     */
+    void set_file(std::optional<std::string_view> file);
 };
 
 auto operator==(const Origin&, const Origin&) noexcept -> bool;
@@ -851,6 +856,7 @@ public:
     [[nodiscard]] auto has_origin() const -> bool;
 
     [[nodiscard]] auto origin() const -> const Origin&;
+    [[nodiscard]] auto origin() -> Origin&;
 
     [[nodiscard]] auto remove_origin() const -> Value;
     [[nodiscard]] auto with_origin(Origin new_origin) const -> Value;

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -729,7 +729,7 @@ public:
     /**
      * Sets the file of the underlying origin type (if possible).
      */
-    void set_file(std::optional<std::string_view> file);
+    void set_file(std::optional<std::shared_ptr<std::string>> file);
 };
 
 auto operator==(const Origin&, const Origin&) noexcept -> bool;

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -355,6 +355,11 @@ public:
     auto has(const Value& key) -> bool;
     void set(const Value& key, Value value);
     void set(Value&& key, Value value);
+    /**
+     * Copy the `other` table into this table overwriting all keys that are
+     * duplicate.
+     */
+    void set_all(const Table& other);
     [[nodiscard]] auto size() const -> size_t;
 
     // iterators for Table

--- a/include/tree_sitter/tree_sitter.hpp
+++ b/include/tree_sitter/tree_sitter.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <exception>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -940,6 +941,26 @@ public:
      */
     std::vector<Node> named_children();
 };
+
+/**
+ * Visits all children of the cursor and call the given function.
+ */
+void visit_children(Cursor& cursor, const std::function<void(ts::Node)>& fn);
+
+/**
+ * Visit all siblings of the cursor and call the given function.
+ */
+void visit_siblings(Cursor& cursor, const std::function<void(ts::Node)>& fn);
+
+/**
+ * Visits a tree using a cursor.
+ */
+template <typename Fn> static void visit_tree(const ts::Tree& tree, Fn fn) {
+    Cursor cursor(tree);
+
+    fn(cursor.current_node());
+    visit_children(cursor, fn);
+}
 
 /**
  * A query is a "pre-compiled" string of S-expression patterns.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,8 +13,9 @@ set(LIB_SRC_LIST
 
 # statically link the stdlib lua files
 add_custom_command(OUTPUT stdlib.lua.o
-      COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/lua && ld -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o stdlib.lua
-      COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o)
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lua/stdlib.lua
+    COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/lua && ld -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o stdlib.lua
+    COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o)
 
 add_library(lua_stdlib
     STATIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 find_package(Boost REQUIRED)
 
-# core
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} PUBLIC_INTERFACE_IMPL)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/details PRIVATE_IMPL)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/core CORE_SRC_LIST)
@@ -12,6 +11,28 @@ set(LIB_SRC_LIST
     ${CORE_SRC_LIST}
     ${TREE_SITTER_WRAPPER_SRC_LIST})
 
+# statically link the stdlib lua files
+add_custom_command(OUTPUT stdlib.lua.o
+      COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/lua && ld -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o stdlib.lua
+      COMMAND objcopy --rename-section .data=.rodata,alloc,load,readonly,data,contents ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o ${CMAKE_CURRENT_BINARY_DIR}/stdlib.lua.o)
+
+add_library(lua_stdlib
+    STATIC
+    stdlib.lua.o)
+
+# tell CMake to not compile the file
+SET_SOURCE_FILES_PROPERTIES(
+    stdlib.lua.o
+    PROPERTIES
+    EXTERNAL_OBJECT true
+    GENERATED true)
+
+# tell CMake to use the C linker
+SET_TARGET_PROPERTIES(
+    lua_stdlib
+    PROPERTIES
+    LINKER_LANGUAGE C)
+
 add_library(${PROJECT_NAME} SHARED ${LIB_SRC_LIST})
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -19,7 +40,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 target_link_libraries(${PROJECT_NAME}
     PRIVATE TreeSitter
-    PRIVATE TreeSitterLua)
+    PRIVATE TreeSitterLua
+    PRIVATE lua_stdlib)
 
 install(TARGETS ${PROJECT_NAME}
         EXPORT ${PROJECT_NAME}

--- a/src/details/interpreter.cpp
+++ b/src/details/interpreter.cpp
@@ -1006,7 +1006,8 @@ auto Interpreter::visit_function_call(ast::FunctionCall call, Env& env) -> EvalR
 
     // move the Env to the CallContext
     auto environment = Environment(env);
-    auto ctx = CallContext(&environment).make_new(arguments);
+    auto ctx =
+        CallContext(&environment).make_new(arguments, call.range().with_file(env.get_file()));
 
     try {
         CallResult call_result = obj.call(ctx);

--- a/src/details/interpreter.cpp
+++ b/src/details/interpreter.cpp
@@ -85,6 +85,10 @@ auto operator<<(std::ostream& o, const EvalResult& self) -> std::ostream& {
 Interpreter::Interpreter(const InterpreterConfig& config) : config(config) {}
 
 auto Interpreter::run(const ts::Tree& tree, Env& env) -> EvalResult {
+    // load the stdlib
+    add_stdlib(env.global());
+    // TODO load the file parts
+
     try {
         return this->visit_root(ast::Program(tree.root_node()), env);
     } catch (const InterpreterException&) {

--- a/src/details/interpreter.cpp
+++ b/src/details/interpreter.cpp
@@ -98,7 +98,7 @@ auto Interpreter::run(const ts::Tree& tree, Env& user_env) -> EvalResult {
     // execute the actual program
     std::shared_ptr<std::string> root_filename = std::make_shared<std::string>("__root__");
     env.set_file(root_filename);
-    this->run_file(tree, env);
+    return this->run_file(tree, env);
 }
 
 auto Interpreter::setup_environment(Env& user_env) -> Env {
@@ -143,7 +143,7 @@ auto Interpreter::load_stdlib() -> ts::Tree {
     std::string stdlib_code(_binary_stdlib_lua_start, _binary_stdlib_lua_end);
 
     try {
-        ts::Tree stdlib_tree = ts::Tree(this->parser.parse_string(std::move(stdlib_code)));
+        ts::Tree stdlib_tree = this->parser.parse_string(std::move(stdlib_code));
 
         // This is just in case. Failing to parse is a bug!!!
         if (stdlib_tree.root_node().has_error()) {

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -114,7 +114,10 @@ private:
     void execute_stdlib(Env& env);
 
     /**
-     * Run a loaded tree.
+     * Run a file.
+     *
+     * The file has to be loaded and parsed into a tree and the file
+     * in Env should be set before calling this method.
      */
     auto run_file(const ts::Tree& tree, Env& env) -> EvalResult;
 

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -10,6 +10,13 @@
 namespace minilua::details {
 
 /**
+ * Add the stdlib to the given table.
+ *
+ * This will only add the parts that are directly implemented in lua.
+ */
+void add_stdlib(Table& table);
+
+/**
  * Internal results of the interpreter.
  *
  * Will be converted to the public minilua::EvalResult when the interpreter

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -104,7 +104,8 @@ public:
     auto run(const ts::Tree& tree, Env& env) -> EvalResult;
 
 private:
-    auto execute_stdlib(Env& env);
+    auto init_stdlib() -> ast::Program;
+    void execute_stdlib(Env& env);
 
     auto visit_root(ast::Program program, Env& env) -> EvalResult;
 

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -104,6 +104,8 @@ public:
     auto run(const ts::Tree& tree, Env& env) -> EvalResult;
 
 private:
+    auto execute_stdlib(Env& env);
+
     auto visit_root(ast::Program program, Env& env) -> EvalResult;
 
     // general

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -97,9 +97,10 @@ auto operator<<(std::ostream&, const EvalResult&) -> std::ostream&;
 struct Interpreter {
 private:
     const InterpreterConfig& config;
+    ts::Parser& parser;
 
 public:
-    Interpreter(const InterpreterConfig& config);
+    Interpreter(const InterpreterConfig& config, ts::Parser& parser);
     auto run(const ts::Tree& tree, Env& env) -> EvalResult;
 
 private:

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -149,6 +149,7 @@ private:
     auto visit_vararg_expression(Env& env) -> EvalResult;
 
     auto visit_table_constructor(ast::Table table_constructor, Env& env) -> EvalResult;
+    auto visit_literal(ast::Literal literal, Env& env) -> EvalResult;
 
     /**
      * Evaluates a list of expressions (like return values, function parameters, etc).

--- a/src/details/interpreter.hpp
+++ b/src/details/interpreter.hpp
@@ -101,11 +101,22 @@ private:
 
 public:
     Interpreter(const InterpreterConfig& config, ts::Parser& parser);
-    auto run(const ts::Tree& tree, Env& env) -> EvalResult;
+    auto run(const ts::Tree& tree, Env& user_env) -> EvalResult;
 
 private:
-    auto init_stdlib() -> ast::Program;
+    /**
+     * Setup the stdlib and overwrite (global) variables with the user defined
+     * once.
+     */
+    auto setup_environment(Env& user_env) -> Env;
+
+    auto load_stdlib() -> ts::Tree;
     void execute_stdlib(Env& env);
+
+    /**
+     * Run a loaded tree.
+     */
+    auto run_file(const ts::Tree& tree, Env& env) -> EvalResult;
 
     auto visit_root(ast::Program program, Env& env) -> EvalResult;
 

--- a/src/index.md
+++ b/src/index.md
@@ -25,7 +25,6 @@ package "Private API" {
 
 ```{.cpp}
 minilua::Interpreter interpreter;
-interpreter.environment().add_default_stdlib();
 
 // parse the program
 if (!interpreter.parse("x_coord = 10; forceValue(x_coord, 25)")) {

--- a/src/internal_env.cpp
+++ b/src/internal_env.cpp
@@ -106,7 +106,7 @@ auto operator<<(std::ostream& os, const Env& self) -> std::ostream& {
         os << "nullopt";
     }
 
-    os << "}\n";
+    return os << "}\n";
 }
 
 }; // namespace minilua

--- a/src/internal_env.cpp
+++ b/src/internal_env.cpp
@@ -85,6 +85,9 @@ auto Env::get_stdin() -> std::istream* { return this->in; }
 auto Env::get_stdout() -> std::ostream* { return this->out; }
 auto Env::get_stderr() -> std::ostream* { return this->err; }
 
+void Env::set_file(std::optional<std::shared_ptr<std::string>> file) { this->file = file; }
+auto Env::get_file() const -> std::optional<std::shared_ptr<std::string>> { return this->file; }
+
 auto Env::allocator() const -> MemoryAllocator* { return this->_allocator; }
 
 auto operator<<(std::ostream& os, const Env& self) -> std::ostream& {
@@ -96,7 +99,14 @@ auto operator<<(std::ostream& os, const Env& self) -> std::ostream& {
         sep = ", ";
     }
 
-    return os << "}\n";
+    os << "}, .file = ";
+    if (self.get_file()) {
+        os << *self.get_file();
+    } else {
+        os << "nullopt";
+    }
+
+    os << "}\n";
 }
 
 }; // namespace minilua

--- a/src/internal_env.cpp
+++ b/src/internal_env.cpp
@@ -100,8 +100,8 @@ auto operator<<(std::ostream& os, const Env& self) -> std::ostream& {
     }
 
     os << "}, .file = ";
-    if (self.get_file()) {
-        os << *self.get_file();
+    if (self.get_file().has_value()) {
+        os << self.get_file().value();
     } else {
         os << "nullopt";
     }

--- a/src/internal_env.hpp
+++ b/src/internal_env.hpp
@@ -42,6 +42,7 @@ class Env {
     Table _global;
     LocalEnv _local;
     std::optional<Vallist> varargs;
+    std::optional<std::shared_ptr<std::string>> file;
 
     // iostreams
     std::istream* in;
@@ -140,6 +141,9 @@ public:
     auto get_stdin() -> std::istream*;
     auto get_stdout() -> std::ostream*;
     auto get_stderr() -> std::ostream*;
+
+    void set_file(std::optional<std::shared_ptr<std::string>> file);
+    auto get_file() const -> std::optional<std::shared_ptr<std::string>>;
 
     [[nodiscard]] auto allocator() const -> MemoryAllocator*;
 };

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -115,7 +115,7 @@ void Interpreter::apply_source_changes(std::vector<SourceChange> source_changes)
     std::cout << "apply_source_changes\n";
 }
 auto Interpreter::evaluate() -> EvalResult {
-    details::Interpreter interpreter{this->config()};
+    details::Interpreter interpreter{this->config(), this->impl->parser};
     return interpreter.run(this->impl->tree, this->impl->env.get_raw_impl().inner);
 }
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -67,30 +67,6 @@ void Interpreter::set_config(InterpreterConfig config) { this->_config = config;
 auto Interpreter::environment() const -> Environment& { return impl->env; }
 auto Interpreter::source_code() const -> std::string_view { return impl->source_code; }
 
-static auto visit_siblings(ts::Cursor& cursor, const std::function<void(ts::Node)>& fn) -> bool;
-static auto visit_children(ts::Cursor& cursor, const std::function<void(ts::Node)>& fn) -> bool {
-    if (cursor.goto_first_child()) {
-        fn(cursor.current_node());
-    }
-    return visit_siblings(cursor, fn);
-};
-
-static auto visit_siblings(ts::Cursor& cursor, const std::function<void(ts::Node)>& fn) -> bool {
-    while (cursor.goto_next_sibling()) {
-        fn(cursor.current_node());
-        visit_children(cursor, fn);
-    }
-    return cursor.goto_parent();
-};
-
-// TODO refactor this and make it more usable
-template <typename Fn> static void visit_tree(const ts::Tree& tree, Fn fn) {
-    ts::Cursor cursor(tree);
-
-    fn(cursor.current_node());
-    visit_children(cursor, fn);
-}
-
 auto Interpreter::parse(std::string source_code) -> ParseResult {
     this->impl->source_code = std::move(source_code);
     this->impl->tree = this->impl->parser.parse_string(this->impl->source_code);

--- a/src/lua/stdlib.lua
+++ b/src/lua/stdlib.lua
@@ -1,7 +1,6 @@
-
 function assert(predicate, message)
     if not predicate then
-        if message != nil then
+        if message ~= nil then
             error(message)
         else
             error("assertion failed!")

--- a/src/lua/stdlib.lua
+++ b/src/lua/stdlib.lua
@@ -1,0 +1,10 @@
+
+function assert(predicate, message)
+    if not predicate then
+        if message != nil then
+            error(message)
+        else
+            error("assertion failed!")
+        end
+    end
+end

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -11,6 +11,13 @@ auto operator<<(std::ostream& os, const Location& self) -> std::ostream& {
 }
 
 // struct Range
+auto Range::with_file(std::optional<std::shared_ptr<std::string>> file) const -> Range {
+    return Range{
+        .start = this->start,
+        .end = this->end,
+        .file = std::move(file),
+    };
+}
 auto operator==(Range lhs, Range rhs) noexcept -> bool {
     // check the internal string for equality instead of the shared_ptr
     bool file_equals = (!lhs.file.has_value() && !lhs.file.has_value()) ||

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -47,6 +47,10 @@ auto SourceChangeTree::hint() -> std::string& {
     return this->visit([](auto& change) -> std::string& { return change.hint; });
 }
 
+void SourceChangeTree::remove_filename() {
+    this->visit_all([](SourceChange& change) { change.range.file = std::nullopt; });
+}
+
 [[nodiscard]] auto SourceChangeTree::collect_first_alternative() const
     -> std::vector<SourceChange> {
     std::vector<SourceChange> changes;

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -11,10 +11,17 @@ auto operator<<(std::ostream& os, const Location& self) -> std::ostream& {
 }
 
 // struct Range
+auto operator==(Range lhs, Range rhs) noexcept -> bool {
+    // check the internal string for equality instead of the shared_ptr
+    bool file_equals = (!lhs.file.has_value() && !lhs.file.has_value()) ||
+                       (lhs.file.has_value() && rhs.file.has_value() && **lhs.file == **rhs.file);
+    return lhs.start == rhs.start && lhs.end == rhs.end && file_equals;
+}
+auto operator!=(Range lhs, Range rhs) noexcept -> bool { return !(lhs == rhs); }
 auto operator<<(std::ostream& os, const Range& self) -> std::ostream& {
     os << "Range{ start = " << self.start << ", end = " << self.end << ", file = ";
     if (self.file) {
-        os << "\"" << *self.file << "\"";
+        os << "\"" << **self.file << "\"";
     } else {
         os << "nullopt";
     }

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -11,20 +11,20 @@ auto operator<<(std::ostream& os, const Location& self) -> std::ostream& {
 }
 
 // struct Range
-auto Range::with_file(std::optional<std::shared_ptr<std::string>> file) const -> Range {
+auto Range::with_file(std::optional<std::shared_ptr<const std::string>> file) const -> Range {
     return Range{
         .start = this->start,
         .end = this->end,
         .file = std::move(file),
     };
 }
-auto operator==(Range lhs, Range rhs) noexcept -> bool {
+auto operator==(const Range& lhs, const Range& rhs) noexcept -> bool {
     // check the internal string for equality instead of the shared_ptr
     bool file_equals = (!lhs.file.has_value() && !lhs.file.has_value()) ||
                        (lhs.file.has_value() && rhs.file.has_value() && **lhs.file == **rhs.file);
     return lhs.start == rhs.start && lhs.end == rhs.end && file_equals;
 }
-auto operator!=(Range lhs, Range rhs) noexcept -> bool { return !(lhs == rhs); }
+auto operator!=(const Range& lhs, const Range& rhs) noexcept -> bool { return !(lhs == rhs); }
 auto operator<<(std::ostream& os, const Range& self) -> std::ostream& {
     os << "Range{ start = " << self.start << ", end = " << self.end << ", file = ";
     if (self.file) {

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -12,7 +12,13 @@ auto operator<<(std::ostream& os, const Location& self) -> std::ostream& {
 
 // struct Range
 auto operator<<(std::ostream& os, const Range& self) -> std::ostream& {
-    return os << "Range{ start = " << self.start << ", end = " << self.end << " }";
+    os << "Range{ start = " << self.start << ", end = " << self.end << ", file = ";
+    if (self.file) {
+        os << "\"" << *self.file << "\"";
+    } else {
+        os << "nullopt";
+    }
+    return os << " }";
 }
 
 // struct SourceChange

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -35,26 +35,6 @@ void error(const CallContext& ctx) {
     throw std::runtime_error(std::get<String>(message.to_string()).value);
 }
 
-/**
-Splits a string into two parts. the split happens at the character c which is not included in the
-result.
-
-Example:
-split_string("123.456", '.') = (123, 456)
-*/
-// commented because not needed at the moment, maybe in the future. if not, delete it
-/*static auto split_string(const std::string& s, char c) -> std::pair<std::string, std::string> {
-    std::pair<std::string, std::string> result;
-    std::stringstream split(s);
-    std::string tmp;
-    std::getline(split, tmp, c);
-    result.first = tmp;
-    std::getline(split, tmp, c);
-    result.second = tmp;
-    return result;
-}
-*/
-
 auto to_string(const CallContext& ctx) -> Value {
     auto arg = ctx.arguments().get(0);
 
@@ -72,19 +52,6 @@ auto type(const CallContext& ctx) -> Value {
     auto v = ctx.arguments().get(0);
 
     return v.type();
-}
-
-auto assert_lua(const CallContext& ctx) -> Vallist {
-    auto v = ctx.arguments().get(0);
-    auto message = ctx.arguments().get(1);
-
-    if (v) {
-        return ctx.arguments();
-    } else {
-        // TODO: improve error behaviour
-        throw std::runtime_error(
-            message == Nil() ? std::string("assertion failed") : get<String>(message).value);
-    }
 }
 
 auto next(const CallContext& ctx) -> Vallist {

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -25,9 +25,16 @@ void add_stdlib(Table& table) {
     table.set("next", next);
     table.set("select", select);
     table.set("print", print);
+    table.set("error", error);
 }
 
 } // namespace details
+
+void error(const CallContext& ctx) {
+    // TODO implement level (we need a proper call stack for that)
+    auto message = ctx.arguments().get(0);
+    throw std::runtime_error(std::get<String>(message.to_string()).value);
+}
 
 /**
 Splits a string into two parts. the split happens at the character c which is not included in the

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -15,15 +15,19 @@
 
 namespace minilua {
 
-void Environment::add_default_stdlib() {
-    this->add("tostring", to_string);
-    this->add("to_number", to_number);
-    this->add("type", type);
-    this->add("assert", assert_lua);
-    this->add("next", next);
-    this->add("select", select);
-    this->add("print", print);
+namespace details {
+
+void add_stdlib(Table& table) {
+    table.set("tostring", to_string);
+    table.set("to_number", to_number);
+    table.set("type", type);
+    table.set("assert", assert_lua);
+    table.set("next", next);
+    table.set("select", select);
+    table.set("print", print);
 }
+
+} // namespace details
 
 /**
 Splits a string into two parts. the split happens at the character c which is not included in the

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -12,6 +12,7 @@
 #include "MiniLua/environment.hpp"
 #include "MiniLua/stdlib.hpp"
 #include "MiniLua/utils.hpp"
+#include "internal_env.hpp"
 
 namespace minilua {
 

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -21,7 +21,6 @@ void add_stdlib(Table& table) {
     table.set("tostring", to_string);
     table.set("to_number", to_number);
     table.set("type", type);
-    table.set("assert", assert_lua);
     table.set("next", next);
     table.set("select", select);
     table.set("print", print);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -161,6 +161,11 @@ auto Table::get(const Value& key) -> Value {
 auto Table::has(const Value& key) -> bool { return impl->value.find(key) != impl->value.end(); }
 void Table::set(const Value& key, Value value) { impl->set(key, std::move(value)); }
 void Table::set(Value&& key, Value value) { impl->set(key, std::move(value)); }
+void Table::set_all(const Table& other) {
+    for (const auto& [key, value] : other) {
+        this->set(key, value);
+    }
+}
 [[nodiscard]] auto Table::size() const -> size_t { return impl->value.size(); }
 
 auto Table::begin() -> Table::iterator {

--- a/src/tree_sitter/tree_sitter.cpp
+++ b/src/tree_sitter/tree_sitter.cpp
@@ -1,5 +1,6 @@
 #include "tree_sitter/tree_sitter.hpp"
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 #include <iostream>
 #include <iterator>
@@ -495,6 +496,22 @@ void Tree::print_dot_graph(std::string_view file) const {
     std::unique_ptr<std::FILE, decltype(&fclose)> f{std::fopen(file.data(), "w"), fclose};
     ts_tree_print_dot_graph(this->raw(), f.get());
 }
+
+// helpers to implement visit_tree
+void visit_children(Cursor& cursor, const std::function<void(ts::Node)>& fn) {
+    if (cursor.goto_first_child()) {
+        fn(cursor.current_node());
+    }
+    visit_siblings(cursor, fn);
+};
+
+void visit_siblings(Cursor& cursor, const std::function<void(ts::Node)>& fn) {
+    while (cursor.goto_next_sibling()) {
+        fn(cursor.current_node());
+        visit_children(cursor, fn);
+    }
+    assert(cursor.goto_parent());
+};
 
 // class Cursor
 Cursor::Cursor(Node node) noexcept : cursor(ts_tree_cursor_new(node.raw())), tree(&node.tree()) {}

--- a/src/tree_sitter/tree_sitter.cpp
+++ b/src/tree_sitter/tree_sitter.cpp
@@ -207,6 +207,7 @@ TypeKind Language::node_type_kind(TypeId type_id) const {
     case TSSymbolTypeAuxiliary:
         return TypeKind::Hidden;
     }
+    throw std::runtime_error("Invalid TypeId");
 }
 
 std::uint32_t Language::version() const { return ts_language_version(this->raw()); }

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -357,7 +357,9 @@ void Origin::set_file(std::optional<std::shared_ptr<std::string>> file) {
                 }
             },
             [&file](LiteralOrigin& origin) { origin.location.file = file; },
-            [](auto& /*unused*/) {}},
+            [](NoOrigin& /*unused*/) {},
+            [](ExternalOrigin& /*unused*/) {},
+        },
         this->origin);
 }
 

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -343,7 +343,7 @@ auto Origin::raw() -> Type& { return this->origin; }
         },
         this->origin);
 }
-void Origin::set_file(std::optional<std::string_view> file) {
+void Origin::set_file(std::optional<std::shared_ptr<std::string>> file) {
     std::visit(
         overloaded{
             [&file](BinaryOrigin& origin) {

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -343,6 +343,23 @@ auto Origin::raw() -> Type& { return this->origin; }
         },
         this->origin);
 }
+void Origin::set_file(std::optional<std::string_view> file) {
+    std::visit(
+        overloaded{
+            [&file](BinaryOrigin& origin) {
+                if (origin.location) {
+                    origin.location->file = file;
+                }
+            },
+            [&file](UnaryOrigin& origin) {
+                if (origin.location) {
+                    origin.location->file = file;
+                }
+            },
+            [&file](LiteralOrigin& origin) { origin.location.file = file; },
+            [](auto& /*unused*/) {}},
+        this->origin);
+}
 
 auto operator==(const Origin& lhs, const Origin& rhs) noexcept -> bool {
     return lhs.raw() == rhs.raw();
@@ -497,6 +514,7 @@ auto Value::raw() const -> const Value::Type& { return impl->val; }
 [[nodiscard]] auto Value::has_origin() const -> bool { return !this->impl->origin.is_none(); }
 
 [[nodiscard]] auto Value::origin() const -> const Origin& { return this->impl->origin; }
+[[nodiscard]] auto Value::origin() -> Origin& { return this->impl->origin; }
 
 [[nodiscard]] auto Value::remove_origin() const -> Value {
     return this->with_origin(Origin{NoOrigin()});

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -133,7 +133,6 @@ TEST_CASE("unit_tests lua files") {
             }
 
             minilua::Interpreter interpreter;
-            interpreter.environment().add_default_stdlib();
             REQUIRE(interpreter.parse(program));
             auto result = interpreter.evaluate();
             REQUIRE(!result.source_change.has_value());

--- a/tests/public_api/integration_tests.cpp
+++ b/tests/public_api/integration_tests.cpp
@@ -29,9 +29,6 @@ TEST_CASE("Interpreter integration test") {
     minilua::Interpreter interpreter;
     interpreter.config().all(true);
 
-    // populate the environment
-    interpreter.environment().add_default_stdlib();
-
     auto lambda = [](minilua::CallContext /*unused*/) { // NOLINT
         return std::string{"force something"};
     };

--- a/tests/public_api/integration_tests.cpp
+++ b/tests/public_api/integration_tests.cpp
@@ -71,7 +71,8 @@ TEST_CASE("Interpreter integration test") {
     REQUIRE(result.source_change.has_value());
     auto range = minilua::Range{
         .start = {0, 10, 10}, // NOLINT
-        .end = {0, 12, 12}    // NOLINT
+        .end = {0, 12, 12},   // NOLINT
+        .file = std::make_shared<std::string>("__root__"),
     };
     auto expected_source_changes = minilua::SourceChangeTree(minilua::SourceChange(range, "25"));
     CHECK(result.source_change.value() == expected_source_changes);

--- a/tests/public_api/integration_tests.cpp
+++ b/tests/public_api/integration_tests.cpp
@@ -71,11 +71,12 @@ TEST_CASE("Interpreter integration test") {
     REQUIRE(result.source_change.has_value());
     auto range = minilua::Range{
         .start = {0, 10, 10}, // NOLINT
-        .end = {0, 12, 12},   // NOLINT
-        .file = std::make_shared<std::string>("__root__"),
+        .end = {0, 12, 12}    // NOLINT
     };
     auto expected_source_changes = minilua::SourceChangeTree(minilua::SourceChange(range, "25"));
-    CHECK(result.source_change.value() == expected_source_changes);
+    auto actual_source_changes = result.source_change.value();
+    actual_source_changes.remove_filename();
+    CHECK(actual_source_changes == expected_source_changes);
 
     // choose source changes to apply
     // TODO do we need a vector here or is is ok to assume that one run of the

--- a/tests/stdlib_tests.cpp
+++ b/tests/stdlib_tests.cpp
@@ -20,7 +20,7 @@ TEST_CASE("assert") {
     SECTION("assert false with message") {
         minilua::Interpreter interpreter;
         REQUIRE(interpreter.parse(R"(assert(false, "message"))"));
-        REQUIRE_THROWS_WITH(interpreter.evaluate(), "message");
+        REQUIRE_THROWS_WITH(interpreter.evaluate(), Catch::Contains("message"));
     }
 }
 

--- a/tests/stdlib_tests.cpp
+++ b/tests/stdlib_tests.cpp
@@ -146,44 +146,6 @@ TEST_CASE("to_number") {
     }
 }
 
-TEST_CASE("assert_lua") {
-    SECTION("Assert fails with default message") {
-        minilua::Environment env;
-        minilua::CallContext ctx(&env);
-        minilua::Vallist list = minilua::Vallist({minilua::Value{false}, minilua::Nil()});
-        ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::assert_lua(ctx), "assertion failed");
-    }
-
-    SECTION("Assert fails with default message") {
-        std::string s = "Hallo Welt!";
-        minilua::Environment env;
-        minilua::CallContext ctx(&env);
-        minilua::Vallist list = minilua::Vallist({minilua::Value{false}, minilua::Value{s}});
-        ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::assert_lua(ctx), s);
-    }
-
-    SECTION("Assert passes") {
-        SECTION("Assert passes with standard true") {
-            minilua::Environment env;
-            minilua::CallContext ctx(&env);
-            minilua::Vallist list = minilua::Vallist({minilua::Value{true}, minilua::Value{42}});
-            ctx = ctx.make_new(list);
-            CHECK(minilua::assert_lua(ctx) == ctx.arguments());
-        }
-
-        SECTION("Assert passes with converted true") {
-            minilua::Environment env;
-            minilua::CallContext ctx(&env);
-            minilua::Vallist list =
-                minilua::Vallist({minilua::Value{42}, minilua::Value{"Hallo Welt!"}});
-            ctx = ctx.make_new(list);
-            CHECK(minilua::assert_lua(ctx) == ctx.arguments());
-        }
-    }
-}
-
 TEST_CASE("select") {
     minilua::Environment env;
     minilua::CallContext ctx(&env);

--- a/tests/stdlib_tests.cpp
+++ b/tests/stdlib_tests.cpp
@@ -2,8 +2,27 @@
 #include <string>
 
 #include "MiniLua/environment.hpp"
+#include "MiniLua/interpreter.hpp"
 #include "MiniLua/stdlib.hpp"
 #include "MiniLua/values.hpp"
+
+TEST_CASE("assert") {
+    SECTION("assert false") {
+        minilua::Interpreter interpreter;
+        REQUIRE(interpreter.parse("assert(false)"));
+        REQUIRE_THROWS(interpreter.evaluate());
+    }
+    SECTION("assert true") {
+        minilua::Interpreter interpreter;
+        REQUIRE(interpreter.parse("assert(true)"));
+        REQUIRE_NOTHROW(interpreter.evaluate());
+    }
+    SECTION("assert false with message") {
+        minilua::Interpreter interpreter;
+        REQUIRE(interpreter.parse(R"(assert(false, "message"))"));
+        REQUIRE_THROWS_WITH(interpreter.evaluate(), "message");
+    }
+}
 
 TEST_CASE("to_string") {
     minilua::Environment env;


### PR DESCRIPTION
Fixes #101

Changes:

- removed `Environment::add_default_stdlib`
- the interpreter now adds the stdlib on the start of every run
  - first the C++ part
  - then the lua  part (which is parsed and executed)
- the stdlib lua file is linked (in binary) into the compiled library (so there are no external files)

Currently the stdlib.lua file only contains the `assert` definition.

TODOs:

- [x] set the filename in Range also for functions calls
- [x] add back the assert tests

Future improvements:

- we could avoid copying the linked `stdlib.lua` char array to a string before parsing (this needs some changes in the tree-sitter wrapper)
