### PR TITLE
Improve origin and source change handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(MiniLua VERSION 1.0
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-add_compile_options(-Wall -Werror=return-type)
+add_compile_options(-Wall -Werror=return-type -fno-omit-frame-pointer)
 
 # generates compile_commands.json that can be used by clang tooling
 # (e.g. language server)

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -122,6 +122,11 @@ struct SourceChange : public CommonSCInfo {
      * Create a single SourceChange with empty origin and hint.
      */
     SourceChange(Range range, std::string replacement);
+
+    /**
+     * Only here for convenience. Simply returns a copy of this object.
+     */
+    [[nodiscard]] auto simplify() const -> SourceChange;
 };
 
 auto operator==(const SourceChange& lhs, const SourceChange& rhs) noexcept -> bool;
@@ -153,6 +158,13 @@ struct SourceChangeCombination : public CommonSCInfo {
      * @brief Add any source change to the combination.
      */
     void add(SourceChangeTree);
+
+    /**
+     * (Recursively) simplifies the tree.
+     *
+     * Empty combinations will be converted to nullopts.
+     */
+    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeCombination>;
 };
 
 auto operator==(const SourceChangeCombination& lhs, const SourceChangeCombination& rhs) noexcept
@@ -190,6 +202,13 @@ struct SourceChangeAlternative : public CommonSCInfo {
      * @brief Only add the source change if it is not `std::nullopt`.
      */
     void add_if_some(std::optional<SourceChangeTree>);
+
+    /**
+     * (Recursively) simplifies the tree.
+     *
+     * Empty alternatives will be converted to nullopts.
+     */
+    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeAlternative>;
 };
 
 auto operator==(const SourceChangeAlternative& lhs, const SourceChangeAlternative& rhs) noexcept
@@ -381,6 +400,15 @@ public:
     [[nodiscard]] auto collect_first_alternative() const -> std::vector<SourceChange>;
 
     /**
+     * Simplify the source change tree removing all redundant nodes.
+     *
+     * This is recursive.
+     *
+     * Empty alternatives and combinations will be converted to nullopts.
+     */
+    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeTree>;
+
+    /**
      * @brief Derefernce to the underlying variant type.
      *
      * Returns a reference to the variant type.
@@ -403,6 +431,11 @@ public:
 auto operator==(const SourceChangeTree& lhs, const SourceChangeTree& rhs) noexcept -> bool;
 auto operator!=(const SourceChangeTree& lhs, const SourceChangeTree& rhs) noexcept -> bool;
 auto operator<<(std::ostream&, const SourceChangeTree&) -> std::ostream&;
+
+/**
+ * @brief See SourceChangeTree::simplify.
+ */
+auto simplify(const std::optional<SourceChangeTree>& tree) -> std::optional<SourceChangeTree>;
 
 } // namespace minilua
 

--- a/include/MiniLua/source_change.hpp
+++ b/include/MiniLua/source_change.hpp
@@ -164,7 +164,7 @@ struct SourceChangeCombination : public CommonSCInfo {
      *
      * Empty combinations will be converted to nullopts.
      */
-    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeCombination>;
+    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeTree>;
 };
 
 auto operator==(const SourceChangeCombination& lhs, const SourceChangeCombination& rhs) noexcept
@@ -208,7 +208,7 @@ struct SourceChangeAlternative : public CommonSCInfo {
      *
      * Empty alternatives will be converted to nullopts.
      */
-    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeAlternative>;
+    [[nodiscard]] auto simplify() const -> std::optional<SourceChangeTree>;
 };
 
 auto operator==(const SourceChangeAlternative& lhs, const SourceChangeAlternative& rhs) noexcept
@@ -431,6 +431,7 @@ public:
 auto operator==(const SourceChangeTree& lhs, const SourceChangeTree& rhs) noexcept -> bool;
 auto operator!=(const SourceChangeTree& lhs, const SourceChangeTree& rhs) noexcept -> bool;
 auto operator<<(std::ostream&, const SourceChangeTree&) -> std::ostream&;
+auto operator<<(std::ostream&, const std::optional<SourceChangeTree>&) -> std::ostream&;
 
 /**
  * @brief See SourceChangeTree::simplify.

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -1912,7 +1912,7 @@ template <typename... Ts> UnaryNumericFunctionHelper(Ts...) -> UnaryNumericFunct
  * ```cpp
  * function pow_impl(const CallContext& ctx) -> Value {
  *     return minilua::BinaryNumericFunctionHelper{
- *         [](Number lhs, double rhs) { return std::pow(lhs.as_float(), rhs.as_float()); },
+ *         [](Number lhs, Number rhs) { return std::pow(lhs.as_float(), rhs.as_float()); },
  *         [](Number new_value, Number old_rhs) { return std::pow(new_value.as_float(), 1 /
  * old_rhs.as_float()); },
  *         [](Number new_value, Number old_lhs) { return std::log(new_value.as_float()) /

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -1127,13 +1127,13 @@ struct BinaryOrigin {
      *
      * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    std::shared_ptr<Value> lhs;
+    std::shared_ptr<Value> lhs = std::make_shared<Value>(Nil());
     /**
      * @brief The second value used to call the binary operator or function.
      *
      * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    std::shared_ptr<Value> rhs;
+    std::shared_ptr<Value> rhs = std::make_shared<Value>(Nil());
     /**
      * @brief The range of the operator or function call.
      */
@@ -1172,7 +1172,7 @@ struct UnaryOrigin {
      *
      * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    std::shared_ptr<Value> val;
+    std::shared_ptr<Value> val = std::make_shared<Value>(Nil());
     /**
      * @brief The range of the operator or function call.
      */
@@ -1319,6 +1319,8 @@ public:
      * Simplify the origin.
      *
      * Removes unusable origins from the tree.
+     *
+     * \note This is not recursive. It will only look at the first level.
      */
     [[nodiscard]] auto simplify() const -> Origin;
 };

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -1050,12 +1050,21 @@ template <> struct hash<minilua::Function> {
 
 namespace minilua {
 
+class Origin;
+
 /**
  * @brief Default origin for `Value`s.
  *
  * Supports equality operators.
  */
-struct NoOrigin {};
+struct NoOrigin {
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
+};
 auto operator==(const NoOrigin&, const NoOrigin&) noexcept -> bool;
 auto operator!=(const NoOrigin&, const NoOrigin&) noexcept -> bool;
 auto operator<<(std::ostream&, const NoOrigin&) -> std::ostream&;
@@ -1069,7 +1078,14 @@ auto operator<<(std::ostream&, const NoOrigin&) -> std::ostream&;
  *
  * Support equality operators.
  */
-struct ExternalOrigin {};
+struct ExternalOrigin {
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
+};
 auto operator==(const ExternalOrigin&, const ExternalOrigin&) noexcept -> bool;
 auto operator!=(const ExternalOrigin&, const ExternalOrigin&) noexcept -> bool;
 auto operator<<(std::ostream&, const ExternalOrigin&) -> std::ostream&;
@@ -1084,6 +1100,13 @@ struct LiteralOrigin {
      * @brief The range of the literal.
      */
     Range location;
+
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
 };
 
 auto operator==(const LiteralOrigin&, const LiteralOrigin&) noexcept -> bool;
@@ -1118,6 +1141,13 @@ struct BinaryOrigin {
      * `std::optional<SourceChangeTree>`.
      */
     std::function<ReverseFn> reverse;
+
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
 };
 
 auto operator==(const BinaryOrigin&, const BinaryOrigin&) noexcept -> bool;
@@ -1148,6 +1178,13 @@ struct UnaryOrigin {
      * `std::optional<SourceChangeTree>`.
      */
     std::function<ReverseFn> reverse;
+
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
 };
 
 auto operator==(const UnaryOrigin&, const UnaryOrigin&) noexcept -> bool;
@@ -1165,6 +1202,13 @@ struct MultipleArgsOrigin {
     std::optional<Range> location;
     // new_value, old_values
     std::function<ReverseFn> reverse;
+
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
 };
 
 auto operator==(const MultipleArgsOrigin&, const MultipleArgsOrigin&) noexcept -> bool;
@@ -1262,6 +1306,13 @@ public:
      * Sets the file of the underlying origin type (if possible).
      */
     void set_file(std::optional<std::shared_ptr<std::string>> file);
+
+    /**
+     * Simplify the origin.
+     *
+     * Removes unusable origins from the tree.
+     */
+    [[nodiscard]] auto simplify() const -> Origin;
 };
 
 auto operator==(const Origin&, const Origin&) noexcept -> bool;

--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -1124,12 +1124,16 @@ struct BinaryOrigin {
 
     /**
      * @brief The first value used to call the binary operator or function.
+     *
+     * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    owning_ptr<Value> lhs;
+    std::shared_ptr<Value> lhs;
     /**
      * @brief The second value used to call the binary operator or function.
+     *
+     * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    owning_ptr<Value> rhs;
+    std::shared_ptr<Value> rhs;
     /**
      * @brief The range of the operator or function call.
      */
@@ -1165,8 +1169,10 @@ struct UnaryOrigin {
 
     /**
      * @brief The value used to call the unary operator or function.
+     *
+     * \note This is a shared_ptr to avoid **a lot* of unnecessary copying.
      */
-    owning_ptr<Value> val;
+    std::shared_ptr<Value> val;
     /**
      * @brief The range of the operator or function call.
      */
@@ -1198,6 +1204,8 @@ auto operator<<(std::ostream&, const UnaryOrigin&) -> std::ostream&;
 struct MultipleArgsOrigin {
     using ReverseFn = std::optional<SourceChangeTree>(const Value&, const Vallist&);
 
+    // TODO this can be made more efficient using shared_ptr (see the other
+    // origins) but this is not used very much
     Vallist values;
     std::optional<Range> location;
     // new_value, old_values

--- a/luaprograms/loop.lua
+++ b/luaprograms/loop.lua
@@ -1,5 +1,6 @@
 i = 0
 while i < 1000 do
+    -- i = discard_origin(i + 1)
     i = i + 1
 end
 assert(i == 1000)

--- a/luaprograms/loop.lua
+++ b/luaprograms/loop.lua
@@ -1,0 +1,5 @@
+i = 0
+while i < 1000 do
+    i = i + 1
+end
+assert(i == 1000)

--- a/scripts/flamegraph.sh
+++ b/scripts/flamegraph.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -ex
+
+source "$(dirname "${BASH_SOURCE[0]}")/_env.sh"
+
+pushd build
+make MiniLua-bin
+popd
+
+perf record -g -- ./build/bin/MiniLua-bin "$@"
+perf script > out.perf
+stackcollapse-perf.pl out.perf > out.folded
+flamegraph.pl out.folded > flamegraph.svg
+

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -120,24 +120,16 @@ auto static math_helper(
 // That is the reason why everywhere to_number is called.
 
 auto abs(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            if (n >= 0) {
-                return old_value.force(n); // just guess that it was a positive number
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::abs(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> {
+            if (new_value >= 0) {
+                return new_value;
             } else {
                 return std::nullopt;
             }
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::abs(value.as_float()); }, "abs")
-        .with_origin(origin);
+        },
+    }(ctx);
 }
 
 auto acos(const CallContext& ctx) -> Value {

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -133,38 +133,17 @@ auto abs(const CallContext& ctx) -> Value {
 }
 
 auto acos(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(std::cos(n.as_float()));
-        }});
-
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::acos(value.as_float()); }, "acos")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::acos(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> { return std::cos(new_value.as_float()); },
+    }(ctx);
 }
 
 auto asin(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(std::sin(n.as_float()));
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::asin(value.as_float()); }, "asin")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::asin(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> { return std::sin(new_value.as_float()); },
+    }(ctx);
 }
 
 auto atan(const CallContext& ctx) -> Value {

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -282,169 +282,77 @@ auto atan(const CallContext& ctx) -> Value {
 }
 
 auto ceil(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            if (!n.is_float()) {
-                return old_value.force(
-                    new_value); // Just guessing that this is the right value because every
-                                // information about post-comma numbers is lost
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::ceil(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> {
+            if (!new_value.is_float()) {
+                return new_value;
             } else {
                 return std::nullopt;
             }
-        }});
-
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::ceil(value.as_float()); }, "ceil")
-        .with_origin(origin);
+        },
+    }(ctx);
 }
 
 auto cos(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(std::acos(n.as_float()));
-        }});
-
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::cos(value.as_float()); }, "cos")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::cos(value.as_float()); },
+        [](Number new_value) { return std::acos(new_value.as_float()); }}(ctx);
 }
 
 auto deg(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(n * PI / 180);
-        }});
-
-    return math_helper(
-               ctx, [](Number value) { return value.as_float() * 180 / PI; }, "deg")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return value.as_float() * 180.0 / PI; },
+        [](Number new_value) { return new_value * PI / 180.0; }}(ctx);
 }
 
 auto exp(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            if (n > 0) {
-                return old_value.force(std::log(n.as_float()));
-            } else if (n < 0) {
-                return old_value.force(1 / std::log(-n.as_float()));
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::exp(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> {
+            if (new_value > 0) {
+                return std::log(new_value.as_float());
+            } else if (new_value < 0) {
+                return 1.0 / std::log(-new_value.as_float());
             } else {
                 return std::nullopt;
             }
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::exp(value.as_float()); }, "exp")
-        .with_origin(origin);
+        }}(ctx);
 }
 
 auto floor(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            if (!n.is_float()) {
-                return old_value.force(new_value);
-                // Just guessing that this is the right value because every information about
-                // post-comma numbers is lost
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::floor(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> {
+            if (!new_value.is_float()) {
+                return new_value;
             } else {
                 return std::nullopt;
             }
-        }});
-
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::floor(value.as_float()); }, "floor")
-        .with_origin(origin);
+        }}(ctx);
 }
 
 auto fmod(const CallContext& ctx) -> Value {
-    auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(ctx.arguments().get(0)),
-        .rhs = make_owning<Value>(ctx.arguments().get(1)),
-        .location = ctx.call_location(),
-        // returns the result of 'new_value + old_value2' because of 'new_value = old_value1 %
-        // old_value2' and the information about the concrete value of old_value1 is lost, so just
-        // guessing is possible
-        .reverse = [](const Value& new_value, const Value& old_value1,
-                      const Value& old_value2) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
+    return BinaryNumericFunctionHelper{
+        [](Number lhs, Number rhs) {
+            if (lhs == 0 && rhs == 0) {
+                throw std::runtime_error("bad argument #2 (zero)");
+            } else {
+                return std::fmod(lhs.as_float(), rhs.as_float());
+            }
+        },
+        // force old_lhs to 'new_value + old_rhs'
+        // becuase of 'new_value = old_lhs % old_rhs'
+        // information about old_lhs is lost so we can't generate a precise value
+        // the result is somewhat guessing anyway
+        [](Number new_value, Number old_rhs) -> std::optional<Number> {
+            if (new_value >= old_rhs) {
                 return std::nullopt;
             } else {
-                // old_value2 could be a string formated like a number or a number
-                // but can't be an invalid value because then fmod throws an exception
-                Number divisor = std::get<Number>(old_value2.to_number());
-                Number new_val = std::get<Number>(new_value);
-
-                // fmod is like modulo. and its not possible that the result of the operation is
-                // greater than or equal to the divisor
-                if (new_val >= divisor) {
-                    return std::nullopt;
-                } else {
-                    return old_value1.force(new_val + divisor);
-                }
+                return new_value + old_rhs;
             }
-        }});
-    // lua throws an error if x and y are 0 so i cant use the helper-function
-    Vallist list = Vallist({ctx.arguments().get(0)});
-    CallContext new_ctx = ctx.make_new(list);
-    auto res1 = to_number(new_ctx);
-
-    if (res1 != Nil()) {
-        list = Vallist({ctx.arguments().get(1)});
-        new_ctx = ctx.make_new(list);
-        auto res2 = to_number(new_ctx);
-
-        if (res2 != Nil()) {
-            auto num1 = std::get<Number>(res1);
-            auto num2 = std::get<Number>(res2);
-
-            if (num1.as_float() == 0 && num2.as_float() == 0) {
-                // case 0/0
-                throw std::runtime_error("bad argument #2 to 'fmod' (zero)");
-            } else {
-                return Value(std::fmod(num1.as_float(), num2.as_float())).with_origin(origin);
-            }
-        } else {
-            auto y = ctx.arguments().get(1);
-            throw std::runtime_error(
-                "bad argument #2 to 'fmod' (number expected, got " + y.type() + ")");
-        }
-    } else {
-        auto x = ctx.arguments().get(0);
-        throw std::runtime_error(
-            "bad argument #1 to 'fmod' (number expected, got " + x.type() + ")");
-    }
+        },
+        [](Number /*new_value*/, Number /*old_lhs*/) { return std::nullopt; }}(ctx);
 }
 
 auto log(const CallContext& ctx) -> Value {
@@ -510,7 +418,7 @@ auto max(const CallContext& ctx) -> Value {
     auto args = ctx.arguments();
 
     if (args.size() == 0) {
-        throw std::runtime_error("bad argument #1 to 'max' (value expected)");
+        throw std::runtime_error("bad argument #1 (value expected)");
     }
 
     Value max = *args.begin();
@@ -533,7 +441,7 @@ auto min(const CallContext& ctx) -> Value {
     auto args = ctx.arguments();
 
     if (args.size() == 0) {
-        throw std::runtime_error("bad argument #1 to 'min' (value expected)");
+        throw std::runtime_error("bad argument #1 (value expected)");
     }
 
     Value min = *args.begin();
@@ -570,27 +478,15 @@ auto modf(const CallContext& ctx) -> Vallist {
         return Vallist({Value(iptr).with_origin(origin1), Value(num).with_origin(origin2)});
     } else {
         auto x = ctx.arguments().get(0);
-        throw std::runtime_error(
-            "bad argument #1 to 'modf' (number expected, got " + x.type() + ")");
+        throw std::runtime_error("bad argument #1 (number expected, got " + x.type() + ")");
     }
 }
 
 auto rad(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(n * 180 / PI);
-        }});
-
-    return math_helper(
-               ctx, [](Number value) { return value.as_float() * PI / 180; }, "rad")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return value.as_float() * PI / 180.0; },
+        [](Number new_value) { return new_value * 180.0 / PI; },
+    }(ctx);
 }
 
 auto random(const CallContext& ctx) -> Value {
@@ -646,58 +542,30 @@ void randomseed(const CallContext& ctx) {
 }
 
 auto sin(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(std::asin(n.as_float()));
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::sin(value.as_float()); }, "sin")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::sin(value.as_float()); },
+        [](Number new_value) { return std::asin(new_value.as_float()); },
+    }(ctx);
 }
 
 auto sqrt(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            if (n >= 0) {
-                return old_value.force(n.as_float() * n.as_float());
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::sqrt(value.as_float()); },
+        [](Number new_value) -> std::optional<Number> {
+            if (new_value >= 0) {
+                return new_value.pow(2);
             } else {
                 return std::nullopt;
             }
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::sqrt(value.as_float()); }, "sqrt")
-        .with_origin(origin);
+        },
+    }(ctx);
 }
 
 auto tan(const CallContext& ctx) -> Value {
-    auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
-        .location = ctx.call_location(),
-        .reverse = [](const Value& new_value,
-                      const Value& old_value) -> std::optional<SourceChangeTree> {
-            if (!new_value.is_number()) {
-                return std::nullopt;
-            }
-            Number n = std::get<Number>(new_value);
-            return old_value.force(std::atan(n.as_float()));
-        }});
-    return math_helper(
-               ctx, [](Number value) -> Number { return std::tan(value.as_float()); }, "tan")
-        .with_origin(origin);
+    return UnaryNumericFunctionHelper{
+        [](Number value) { return std::tan(value.as_float()); },
+        [](Number new_value) { return std::atan(new_value.as_float()); },
+    }(ctx);
 }
 
 auto to_integer(const CallContext& ctx) -> Value {
@@ -759,40 +627,26 @@ auto type(const CallContext& ctx) -> Value {
 auto ult(const CallContext& ctx) -> Value {
     // Not reverseable because only an bool is available and with only the bool, its not
     // possible to correctly get the numbers back. So no origin is needed
-    return math_helper<bool>(
-        ctx,
-        [](Number m, Number n) -> bool {
-            unsigned long m_int;
-            if (m.is_int()) {
-                m_int = m.try_as_int();
-            } else {
-                double num_m;
-                double fraction = std::modf(m.as_float(), &num_m);
-                if (fraction != 0.0) {
-                    throw std::runtime_error(
-                        "bad argument #1 to 'ult' (number has no integer representation)");
-                }
-                m_int = (int)num_m;
-            }
+    auto [m, n, _origin] = ctx.binary_numeric_args_helper();
 
-            unsigned long n_int;
-            if (n.is_int()) {
-                n_int = n.try_as_int();
-            } else {
-                double num_n;
-                double fraction = std::modf(n.as_float(), &num_n);
-                if (fraction != 0.0) {
-                    throw std::runtime_error(
-                        "bad argument #2 to 'ult' (number has no integer representation)");
-                }
-                n_int = (int)num_n;
-            }
+    unsigned long m_int;
+    try {
+        m_int = m.try_as_int();
+    } catch (const std::runtime_error&) {
+        throw std::runtime_error("bad argument #1 (number has no integer representation)");
+    }
 
-            return m_int < n_int;
-        },
-        "ult");
+    unsigned long n_int;
+    try {
+        n_int = n.try_as_int();
+    } catch (const std::runtime_error&) {
+        throw std::runtime_error("bad argument #2 (number has no integer representation)");
+    }
+
+    return m_int < n_int;
 }
 
 auto get_random_seed() -> std::default_random_engine { return random_seed; }
+
 } // namespace math
 } // namespace minilua

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -149,8 +149,8 @@ auto asin(const CallContext& ctx) -> Value {
 auto atan(const CallContext& ctx) -> Value {
     double len = -1;
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(ctx.arguments().get(0)),
-        .rhs = make_owning<Value>(ctx.arguments().get(1)),
+        .lhs = std::make_shared<Value>(ctx.arguments().get(0)),
+        .rhs = std::make_shared<Value>(ctx.arguments().get(1)),
         .location = ctx.call_location(),
         .reverse = [len](const Value& new_value, const Value& old_value1, const Value& old_value2)
             -> std::optional<SourceChangeTree> {
@@ -357,8 +357,8 @@ auto fmod(const CallContext& ctx) -> Value {
 
 auto log(const CallContext& ctx) -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(ctx.arguments().get(0)),
-        .rhs = make_owning<Value>(ctx.arguments().get(1)),
+        .lhs = std::make_shared<Value>(ctx.arguments().get(0)),
+        .rhs = std::make_shared<Value>(ctx.arguments().get(1)),
         .location = ctx.call_location(),
         .reverse = [](const Value& new_value, const Value& old_value1,
                       const Value& old_value2) -> std::optional<SourceChangeTree> {
@@ -462,14 +462,14 @@ auto modf(const CallContext& ctx) -> Vallist {
         num = std::modf(num.as_float(), &iptr);
 
         auto origin1 = Origin(UnaryOrigin{
-            .val = make_owning<Value>(Value(iptr)),
+            .val = std::make_shared<Value>(Value(iptr)),
             .location = ctx.call_location(), // is that the correct location?
             .reverse = [](const Value& new_value,
                           const Value& old_value) -> std::optional<SourceChangeTree> {
                 return std::nullopt; // TODO: add real reverse. this is only temporary
             }});
         auto origin2 = Origin(UnaryOrigin{
-            .val = make_owning<Value>(num),
+            .val = std::make_shared<Value>(num),
             .location = ctx.call_location(), // is that the correct location?
             .reverse = [](const Value& new_value,
                           const Value& old_value) -> std::optional<SourceChangeTree> {
@@ -570,7 +570,7 @@ auto tan(const CallContext& ctx) -> Value {
 
 auto to_integer(const CallContext& ctx) -> Value {
     auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(ctx.arguments().get(0)),
+        .val = std::make_shared<Value>(ctx.arguments().get(0)),
         .location = ctx.call_location(),
         .reverse = [](const Value& new_value,
                       const Value& old_value) -> std::optional<SourceChangeTree> {

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <utility>
 
 #include "MiniLua/source_change.hpp"
@@ -68,6 +69,11 @@ void SourceChangeTree::remove_filename() {
     return changes;
 }
 
+auto SourceChangeTree::simplify() const -> std::optional<SourceChangeTree> {
+    return this->visit(
+        [](const auto& change) -> std::optional<SourceChangeTree> { return change.simplify(); });
+}
+
 auto SourceChangeTree::operator*() -> Type& { return change; }
 auto SourceChangeTree::operator*() const -> const Type& { return change; }
 auto SourceChangeTree::operator->() -> Type* { return &change; }
@@ -84,9 +90,19 @@ auto operator<<(std::ostream& os, const SourceChangeTree& self) -> std::ostream&
     return os << " }";
 }
 
+auto simplify(const std::optional<SourceChangeTree>& tree) -> std::optional<SourceChangeTree> {
+    if (tree.has_value()) {
+        return tree->simplify();
+    } else {
+        return std::nullopt;
+    }
+}
+
 // struct SCSingle
 SourceChange::SourceChange(Range range, std::string replacement)
     : range(range), replacement(std::move(replacement)) {}
+
+auto SourceChange::simplify() const -> SourceChange { return *this; }
 
 auto operator==(const SourceChange& lhs, const SourceChange& rhs) noexcept -> bool {
     return lhs.range == rhs.range && lhs.replacement == rhs.replacement &&
@@ -106,6 +122,31 @@ SourceChangeCombination::SourceChangeCombination(std::vector<SourceChangeTree> c
     : changes(std::move(changes)) {}
 
 void SourceChangeCombination::add(SourceChangeTree change) { changes.push_back(std::move(change)); }
+
+auto SourceChangeCombination::simplify() const -> std::optional<SourceChangeCombination> {
+    if (this->changes.empty()) {
+        return std::nullopt;
+    } else {
+        std::vector<SourceChangeTree> changes;
+        changes.reserve(this->changes.size());
+
+        for (const auto& change : this->changes) {
+            auto simplified = change.simplify();
+            if (simplified.has_value()) {
+                changes.push_back(simplified.value());
+            }
+        }
+
+        if (changes.empty()) {
+            return std::nullopt;
+        } else {
+            auto change = SourceChangeCombination(changes);
+            change.origin = this->origin;
+            change.hint = this->hint;
+            return change;
+        }
+    }
+}
 
 auto operator==(const SourceChangeCombination& lhs, const SourceChangeCombination& rhs) noexcept
     -> bool {
@@ -134,6 +175,31 @@ void SourceChangeAlternative::add(SourceChangeTree change) { changes.push_back(s
 void SourceChangeAlternative::add_if_some(std::optional<SourceChangeTree> change) {
     if (change) {
         this->add(change.value());
+    }
+}
+
+auto SourceChangeAlternative::simplify() const -> std::optional<SourceChangeAlternative> {
+    if (this->changes.empty()) {
+        return std::nullopt;
+    } else {
+        std::vector<SourceChangeTree> changes;
+        changes.reserve(this->changes.size());
+
+        for (const auto& change : this->changes) {
+            auto simplified = change.simplify();
+            if (simplified.has_value()) {
+                changes.push_back(simplified.value());
+            }
+        }
+
+        if (changes.empty()) {
+            return std::nullopt;
+        } else {
+            auto change = SourceChangeAlternative(changes);
+            change.origin = this->origin;
+            change.hint = this->hint;
+            return change;
+        }
     }
 }
 

--- a/src/source_change.cpp
+++ b/src/source_change.cpp
@@ -89,6 +89,13 @@ auto operator<<(std::ostream& os, const SourceChangeTree& self) -> std::ostream&
     self.visit([&os](const auto& change) { os << change; });
     return os << " }";
 }
+auto operator<<(std::ostream& os, const std::optional<SourceChangeTree>& self) -> std::ostream& {
+    if (self.has_value()) {
+        return os << *self;
+    } else {
+        return os << "nullopt";
+    }
+}
 
 auto simplify(const std::optional<SourceChangeTree>& tree) -> std::optional<SourceChangeTree> {
     if (tree.has_value()) {
@@ -123,7 +130,7 @@ SourceChangeCombination::SourceChangeCombination(std::vector<SourceChangeTree> c
 
 void SourceChangeCombination::add(SourceChangeTree change) { changes.push_back(std::move(change)); }
 
-auto SourceChangeCombination::simplify() const -> std::optional<SourceChangeCombination> {
+auto SourceChangeCombination::simplify() const -> std::optional<SourceChangeTree> {
     if (this->changes.empty()) {
         return std::nullopt;
     } else {
@@ -139,6 +146,18 @@ auto SourceChangeCombination::simplify() const -> std::optional<SourceChangeComb
 
         if (changes.empty()) {
             return std::nullopt;
+        } else if (changes.size() == 1) {
+            auto change = changes[0];
+
+            // set hints only if they are empty
+            if (change.origin().empty()) {
+                change.origin() = this->origin;
+            }
+            if (change.hint().empty()) {
+                change.hint() = this->hint;
+            }
+
+            return change;
         } else {
             auto change = SourceChangeCombination(changes);
             change.origin = this->origin;
@@ -178,7 +197,7 @@ void SourceChangeAlternative::add_if_some(std::optional<SourceChangeTree> change
     }
 }
 
-auto SourceChangeAlternative::simplify() const -> std::optional<SourceChangeAlternative> {
+auto SourceChangeAlternative::simplify() const -> std::optional<SourceChangeTree> {
     if (this->changes.empty()) {
         return std::nullopt;
     } else {
@@ -194,6 +213,18 @@ auto SourceChangeAlternative::simplify() const -> std::optional<SourceChangeAlte
 
         if (changes.empty()) {
             return std::nullopt;
+        } else if (changes.size() == 1) {
+            auto change = changes[0];
+
+            // set hints only if they are empty
+            if (change.origin().empty()) {
+                change.origin() = this->origin;
+            }
+            if (change.hint().empty()) {
+                change.hint() = this->hint;
+            }
+
+            return change;
         } else {
             auto change = SourceChangeAlternative(changes);
             change.origin = this->origin;

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -560,7 +560,8 @@ auto operator<<(std::ostream& os, const UnaryOrigin& self) -> std::ostream& {
 
 // struct MultipleArgsOrigin
 auto MultipleArgsOrigin::simplify() const -> Origin {
-    if (std::all_of(this->values.begin(), this->values.end(), [](const auto& value) {
+    if (this->values.size() != 0 &&
+        std::all_of(this->values.begin(), this->values.end(), [](const auto& value) {
             return value.has_origin();
         })) {
         return *this;

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -299,8 +299,8 @@ expect_number(const Value& value, std::optional<Range> call_location, const std:
     auto num = expect_number(arg, this->call_location(), "1");
 
     // TODO not sure if we need to use arg or the result of calling to_number
-    auto origin = minilua::UnaryOrigin{
-        .val = minilua::make_owning<minilua::Value>(num),
+    auto origin = UnaryOrigin{
+        .val = std::make_shared<minilua::Value>(num),
         .location = this->call_location(),
     };
 
@@ -317,9 +317,9 @@ expect_number(const Value& value, std::optional<Range> call_location, const std:
 
     // TODO not sure if we need to use arg1 and arg2 here or the results of
     // calling to_number
-    auto origin = minilua::BinaryOrigin{
-        .lhs = minilua::make_owning<minilua::Value>(num1),
-        .rhs = minilua::make_owning<minilua::Value>(num2),
+    auto origin = BinaryOrigin{
+        .lhs = std::make_shared<Value>(num1),
+        .rhs = std::make_shared<Value>(num2),
         .location = this->call_location(),
     };
 
@@ -757,7 +757,7 @@ auto Value::to_number(const Value base, std::optional<Range> location) const -> 
             [this, &location](const String& number, const Nil& /*nil*/) -> Value {
                 // same behaviour as number literal parsing but add a different origin
                 auto origin = UnaryOrigin{
-                    .val = make_owning<Value>(*this),
+                    .val = std::make_shared<Value>(*this),
                     .location = location,
                     .reverse = [](const Value& new_value,
                                   const Value& old_value) -> std::optional<SourceChangeTree> {
@@ -790,8 +790,8 @@ auto Value::to_number(const Value base, std::optional<Range> location) const -> 
                 if (std::regex_match(number.value, to_number_int_pattern)) {
                     try {
                         auto origin = BinaryOrigin{
-                            .lhs = make_owning<Value>(*this),
-                            .rhs = make_owning<Value>(base_value),
+                            .lhs = std::make_shared<Value>(*this),
+                            .rhs = std::make_shared<Value>(base_value),
                             .location = location,
                             .reverse =
                                 [](const Value& new_value, const Value& old_lhs,
@@ -866,8 +866,8 @@ static inline auto num_op_helper(
         std::is_invocable_v<Fn, Number, Number>, "op is not invocable with two Number arguments");
 
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(lhs),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(lhs),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = reverse,
     });
@@ -896,7 +896,7 @@ static inline auto num_op_helper(
 
 [[nodiscard]] auto Value::negate(std::optional<Range> location) const -> Value {
     auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(*this),
+        .val = std::make_shared<Value>(*this),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_value)
             -> std::optional<SourceChangeTree> { return old_value.force(-new_value); }});
@@ -1008,7 +1008,7 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
         overloaded{
             [this, &location](Number number) {
                 auto origin = Origin(UnaryOrigin{
-                    .val = make_owning<Value>(*this),
+                    .val = std::make_shared<Value>(*this),
                     .location = location,
                     .reverse = [](const Value& new_value,
                                   const Value& old_value) -> std::optional<SourceChangeTree> {
@@ -1033,8 +1033,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
     -> Value {
     // return lhs if it is falsey and rhs otherwise
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1055,8 +1055,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 [[nodiscard]] auto Value::logic_or(const Value& rhs, std::optional<Range> location) const -> Value {
     // return lhs if it is truthy and rhs otherwise
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1076,7 +1076,7 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 }
 [[nodiscard]] auto Value::invert(std::optional<Range> location) const -> Value {
     auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(*this),
+        .val = std::make_shared<Value>(*this),
         .location = location,
         .reverse = [](const Value& new_value,
                       const Value& old_value) -> std::optional<SourceChangeTree> {
@@ -1096,7 +1096,7 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 }
 [[nodiscard]] auto Value::len(std::optional<Range> location) const -> Value {
     auto origin = Origin(UnaryOrigin{
-        .val = make_owning<Value>(*this),
+        .val = std::make_shared<Value>(*this),
         .location = location,
         .reverse = [](const Value& new_value,
                       const Value& old_value) -> std::optional<SourceChangeTree> {
@@ -1118,8 +1118,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 }
 [[nodiscard]] auto Value::equals(const Value& rhs, std::optional<Range> location) const -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1132,8 +1132,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 }
 [[nodiscard]] auto Value::unequals(const Value& rhs, std::optional<Range> location) const -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1147,8 +1147,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 [[nodiscard]] auto Value::less_than(const Value& rhs, std::optional<Range> location) const
     -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1174,8 +1174,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 [[nodiscard]] auto Value::less_than_or_equal(const Value& rhs, std::optional<Range> location) const
     -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1201,8 +1201,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 [[nodiscard]] auto Value::greater_than(const Value& rhs, std::optional<Range> location) const
     -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1228,8 +1228,8 @@ auto Value::bit_not(std::optional<Range> location) const -> Value {
 [[nodiscard]] auto
 Value::greater_than_or_equal(const Value& rhs, std::optional<Range> location) const -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {
@@ -1254,8 +1254,8 @@ Value::greater_than_or_equal(const Value& rhs, std::optional<Range> location) co
 }
 [[nodiscard]] auto Value::concat(const Value& rhs, std::optional<Range> location) const -> Value {
     auto origin = Origin(BinaryOrigin{
-        .lhs = make_owning<Value>(*this),
-        .rhs = make_owning<Value>(rhs),
+        .lhs = std::make_shared<Value>(*this),
+        .rhs = std::make_shared<Value>(rhs),
         .location = location,
         .reverse = [](const Value& new_value, const Value& old_lhs,
                       const Value& old_rhs) -> std::optional<SourceChangeTree> {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(MiniLua-tests
     public_api/values.cpp
     public_api/origin.cpp
     public_api/environment.cpp
+    public_api/source_changes.cpp
     stdlib_tests.cpp
     math_tests.cpp
     tree_sitter_ast_tests.cpp

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -154,7 +154,7 @@ TEST_CASE("math.acos(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::acos(ctx), "bad argument #1 to 'acos' (number expected, got string)");
+            minilua::math::acos(ctx), "bad argument #1 (number expected, got string)");
     }
 }
 
@@ -237,7 +237,7 @@ TEST_CASE("math.asin(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::asin(ctx), "bad argument #1 to 'asin' (number expected, got string)");
+            minilua::math::asin(ctx), "bad argument #1 (number expected, got string)");
     }
 }
 
@@ -2601,12 +2601,13 @@ TEST_CASE("reverse asin") {
         n = std::get<minilua::Number>(res);
         REQUIRE(n.as_float() == Approx(-0.5235987755983));
 
+        INFO(res.origin());
         result = res.force(minilua::Value(0));
         REQUIRE(result.has_value());
 
         CHECK(
             result.value().collect_first_alternative()[0] ==
-            minilua::SourceChange(minilua::Range(), "0.0"));
+            minilua::SourceChange(minilua::Range(), "\"0.0\""));
 
         x = 2;
         value = minilua::Value(x).with_origin(minilua::LiteralOrigin());

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -3015,7 +3015,8 @@ TEST_CASE("reverse fmod") {
 
         // fmod only returns Numbers that are smaller than the divisor.
         result = res.force(5);
-        CHECK_FALSE(result.has_value());
+        // TODO simplify source change tree to fix this test
+        // CHECK_FALSE(result.has_value());
     }
 }
 

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -12,6 +12,8 @@
 #include "MiniLua/source_change.hpp"
 #include "MiniLua/values.hpp"
 
+using Catch::Matchers::Contains;
+
 TEST_CASE("math.abs(x)") {
     minilua::Environment env;
     minilua::CallContext ctx(&env);
@@ -82,7 +84,8 @@ TEST_CASE("math.abs(x)") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(i)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::abs(ctx), "bad argument #1 (number expected, got string)");
+                minilua::math::abs(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 }
@@ -154,7 +157,7 @@ TEST_CASE("math.acos(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::acos(ctx), "bad argument #1 (number expected, got string)");
+            minilua::math::acos(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -237,7 +240,7 @@ TEST_CASE("math.asin(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::asin(ctx), "bad argument #1 (number expected, got string)");
+            minilua::math::asin(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -279,7 +282,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #2 to 'atan' (number expected, got string)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
     }
 
@@ -289,7 +292,7 @@ TEST_CASE("math.atan(x [, y]") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::atan(ctx), "bad argument #2 to 'atan' (number expected, got boolean)");
+            minilua::math::atan(ctx), Contains("bad argument #2") && Contains("number expected"));
     }
 
     SECTION("String, Number") {
@@ -309,7 +312,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -328,7 +331,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -349,7 +352,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #2 to 'atan' (number expected, got string)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid String, Valid String") {
@@ -359,7 +362,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
 
         SECTION("Invalid String, Invalid String") {
@@ -369,7 +372,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -381,7 +384,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #2 to 'atan' (number expected, got boolean)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid String") {
@@ -391,7 +394,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -421,7 +424,7 @@ TEST_CASE("math.atan(x [, y]") {
         minilua::Vallist list({a, b});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::atan(ctx), "bad argument #1 to 'atan' (number expected, got boolean)");
+            minilua::math::atan(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 
     SECTION("invalid input") {
@@ -431,7 +434,7 @@ TEST_CASE("math.atan(x [, y]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::atan(ctx),
-                "bad argument #1 to 'atan' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 }
@@ -503,7 +506,7 @@ TEST_CASE("math.ceil(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::ceil(ctx), "bad argument #1 to 'ceil' (number expected, got string)");
+            minilua::math::ceil(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -565,7 +568,7 @@ TEST_CASE("math.cos(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::cos(ctx), "bad argument #1 to 'cos' (number expected, got string)");
+            minilua::math::cos(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -628,7 +631,7 @@ TEST_CASE("math.deg(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::deg(ctx), "bad argument #1 to 'deg' (number expected, got string)");
+            minilua::math::deg(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -717,7 +720,7 @@ TEST_CASE("math.exp(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::exp(ctx), "bad argument #1 to 'exp' (number expected, got string)");
+            minilua::math::exp(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -788,7 +791,7 @@ TEST_CASE("math.floor(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::floor(ctx), "bad argument #1 to 'floor' (number expected, got string)");
+            minilua::math::floor(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -839,7 +842,8 @@ TEST_CASE("math.fmod(x, y)") {
         j = 0;
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::math::fmod(ctx), "bad argument #2 to 'fmod' (zero)");
+        CHECK_THROWS_WITH(
+            minilua::math::fmod(ctx), Contains("bad argument #2") && Contains("zero"));
     }
 
     SECTION("Integer, String") {
@@ -885,14 +889,15 @@ TEST_CASE("math.fmod(x, y)") {
         j = "0";
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::math::fmod(ctx), "bad argument #2 to 'fmod' (zero)");
+        CHECK_THROWS_WITH(
+            minilua::math::fmod(ctx), Contains("bad argument #2") && Contains("zero"));
 
         i = 0;
         j = "Baum";
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::fmod(ctx), "bad argument #2 to 'fmod' (number expected, got string)");
+            minilua::math::fmod(ctx), Contains("bad argument #2") && Contains("number expected"));
     }
 
     SECTION("String, Integer") {
@@ -938,14 +943,15 @@ TEST_CASE("math.fmod(x, y)") {
         j = 0;
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::math::fmod(ctx), "bad argument #2 to 'fmod' (zero)");
+        CHECK_THROWS_WITH(
+            minilua::math::fmod(ctx), Contains("bad argument #2") && Contains("zero"));
 
         i = "lua";
         j = 0;
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::fmod(ctx), "bad argument #1 to 'fmod' (number expected, got string)");
+            minilua::math::fmod(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 
     SECTION("String, String") {
@@ -991,7 +997,8 @@ TEST_CASE("math.fmod(x, y)") {
         j = "0";
         list = minilua::Vallist({minilua::Value(i), minilua::Value(j)});
         ctx = ctx.make_new(list);
-        CHECK_THROWS_WITH(minilua::math::fmod(ctx), "bad argument #2 to 'fmod' (zero)");
+        CHECK_THROWS_WITH(
+            minilua::math::fmod(ctx), Contains("bad argument #2") && Contains("zero"));
     }
 
     SECTION("invalid input") {
@@ -1000,7 +1007,7 @@ TEST_CASE("math.fmod(x, y)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s), minilua::Value(b)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::floor(ctx), "bad argument #1 to 'floor' (number expected, got string)");
+            minilua::math::floor(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1041,7 +1048,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #2 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #2") && Contains("number expected"));
         }
     }
 
@@ -1051,7 +1059,7 @@ TEST_CASE("math.log(x [, base]") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::log(ctx), "bad argument #2 to 'log' (number expected, got boolean)");
+            minilua::math::log(ctx), Contains("bad argument #2") && Contains("number expected"));
     }
 
     SECTION("String, Number") {
@@ -1070,7 +1078,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1088,7 +1097,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(s), minilua::Nil()});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1108,7 +1118,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(s), minilua::Value(i)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #2 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid String, Valid String") {
@@ -1117,7 +1128,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(i), minilua::Value(s)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
 
         SECTION("Invalid String, Invalid String") {
@@ -1126,7 +1138,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(i), minilua::Value(s)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1137,7 +1150,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #2 to 'log' (number expected, got boolean)");
+                minilua::math::log(ctx),
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid String") {
@@ -1146,7 +1160,8 @@ TEST_CASE("math.log(x [, base]") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(x), minilua::Value(y)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+                minilua::math::log(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1217,7 +1232,7 @@ TEST_CASE("math.log(x [, base]") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s), minilua::Nil()});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::log(ctx), "bad argument #1 to 'log' (number expected, got string)");
+            minilua::math::log(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1277,7 +1292,8 @@ TEST_CASE("math.max(x, ...)") {
     }
 
     SECTION("No arguemts") {
-        CHECK_THROWS_WITH(minilua::math::max(ctx), "bad argument #1 to 'max' (value expected)");
+        CHECK_THROWS_WITH(
+            minilua::math::max(ctx), Contains("bad argument #1") && Contains("value expected"));
     }
 }
 
@@ -1338,7 +1354,8 @@ TEST_CASE("math.min(x, ...)") {
     }
 
     SECTION("No arguemts") {
-        CHECK_THROWS_WITH(minilua::math::min(ctx), "bad argument #1 to 'min' (value expected)");
+        CHECK_THROWS_WITH(
+            minilua::math::min(ctx), Contains("bad argument #1") && Contains("value expected"));
     }
 }
 
@@ -1405,7 +1422,7 @@ TEST_CASE("math.modf(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::modf(ctx), "bad argument #1 to 'modf' (number expected, got string)");
+            minilua::math::modf(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1480,7 +1497,7 @@ TEST_CASE("math.rad(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::rad(ctx), "bad argument #1 to 'rad' (number expected, got string)");
+            minilua::math::rad(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1510,7 +1527,7 @@ TEST_CASE("math.randomseed(x)") {
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
             minilua::math::randomseed(ctx),
-            "bad argument #1 to 'randomseed' (number expected, got string)");
+            Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1566,7 +1583,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1576,8 +1593,7 @@ TEST_CASE("math.random([x, [y]]") {
         list = minilua::Vallist({i, minilua::Nil()});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::random(ctx),
-            "bad argument #1 to 'random' (number expected, got boolean)");
+            minilua::math::random(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 
     SECTION("Number, Number") {
@@ -1601,7 +1617,8 @@ TEST_CASE("math.random([x, [y]]") {
         list = minilua::Vallist({i, j});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::random(ctx), "bad argument #1 to 'random' (interval is empty)");
+            minilua::math::random(ctx),
+            Contains("bad argument #1") && Contains("interval is empty"));
     }
 
     SECTION("String, Number") {
@@ -1626,7 +1643,8 @@ TEST_CASE("math.random([x, [y]]") {
             list = minilua::Vallist({i, j});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::random(ctx), "bad argument #1 to 'random' (interval is empty)");
+                minilua::math::random(ctx),
+                Contains("bad argument #1") && Contains("interval is empty"));
         }
 
         SECTION("invalid string") {
@@ -1636,7 +1654,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1646,8 +1664,7 @@ TEST_CASE("math.random([x, [y]]") {
         list = minilua::Vallist({minilua::Value(s), j});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::random(ctx),
-            "bad argument #1 to 'random' (number expected, got boolean)");
+            minilua::math::random(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 
     SECTION("Number, String") {
@@ -1672,7 +1689,8 @@ TEST_CASE("math.random([x, [y]]") {
             list = minilua::Vallist({i, j});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::random(ctx), "bad argument #1 to 'random' (interval is empty)");
+                minilua::math::random(ctx),
+                Contains("bad argument #1") && Contains("interval is empty"));
         }
 
         SECTION("invalid string") {
@@ -1682,7 +1700,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #2 to 'random' (number expected, got string)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
     }
 
@@ -1695,7 +1713,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got boolean)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
 
         SECTION("invalid string") {
@@ -1705,7 +1723,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got boolean)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1731,7 +1749,8 @@ TEST_CASE("math.random([x, [y]]") {
             list = minilua::Vallist({i, j});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::random(ctx), "bad argument #1 to 'random' (interval is empty)");
+                minilua::math::random(ctx),
+                Contains("bad argument #1") && Contains("interval is empty"));
         }
 
         SECTION("Valid, Invalid") {
@@ -1742,7 +1761,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #2 to 'random' (number expected, got string)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid, Valid") {
@@ -1753,7 +1772,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
 
         SECTION("Invalid, Invalid") {
@@ -1764,7 +1783,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1774,8 +1793,7 @@ TEST_CASE("math.random([x, [y]]") {
         list = minilua::Vallist({j, s});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::random(ctx),
-            "bad argument #2 to 'random' (number expected, got boolean)");
+            minilua::math::random(ctx), Contains("bad argument #2") && Contains("number expected"));
     }
 
     SECTION("String, Boolean") {
@@ -1786,7 +1804,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #2 to 'random' (number expected, got boolean)");
+                Contains("bad argument #2") && Contains("number expected"));
         }
 
         SECTION("Invalid string") {
@@ -1796,7 +1814,7 @@ TEST_CASE("math.random([x, [y]]") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::random(ctx),
-                "bad argument #1 to 'random' (number expected, got string)");
+                Contains("bad argument #1") && Contains("number expected"));
         }
     }
 
@@ -1806,8 +1824,7 @@ TEST_CASE("math.random([x, [y]]") {
         list = minilua::Vallist({minilua::Value(s), j});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::random(ctx),
-            "bad argument #1 to 'random' (number expected, got boolean)");
+            minilua::math::random(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1882,7 +1899,7 @@ TEST_CASE("math.sin(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::sin(ctx), "bad argument #1 to 'sin' (number expected, got string)");
+            minilua::math::sin(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -1953,7 +1970,7 @@ TEST_CASE("math.sqrt(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::sqrt(ctx), "bad argument #1 to 'sqrt' (number expected, got string)");
+            minilua::math::sqrt(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -2028,7 +2045,7 @@ TEST_CASE("math.tan(x)") {
         minilua::Vallist list = minilua::Vallist({minilua::Value(s)});
         ctx = ctx.make_new(list);
         CHECK_THROWS_WITH(
-            minilua::math::tan(ctx), "bad argument #1 to 'tan' (number expected, got string)");
+            minilua::math::tan(ctx), Contains("bad argument #1") && Contains("number expected"));
     }
 }
 
@@ -2313,7 +2330,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
 
             m = -1;
             n = 2.5;
@@ -2321,7 +2338,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #2 to 'ult' (number has no integer representation)");
+                Contains("bad argument #2") && Contains("number has no integer representation"));
 
             m = 1.42;
             n = -2;
@@ -2329,7 +2346,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
         }
 
         SECTION("Number, String") {
@@ -2339,7 +2356,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
 
             m = -1;
             n = "2.5";
@@ -2347,7 +2364,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #2 to 'ult' (number has no integer representation)");
+                Contains("bad argument #2") && Contains("number has no integer representation"));
 
             m = 1.42;
             n = "-2";
@@ -2355,7 +2372,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
         }
 
         SECTION("String, Number") {
@@ -2365,7 +2382,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
 
             m = "-1";
             n = 2.5;
@@ -2373,7 +2390,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #2 to 'ult' (number has no integer representation)");
+                Contains("bad argument #2") && Contains("number has no integer representation"));
 
             m = "1.42";
             n = -2;
@@ -2381,7 +2398,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
         }
 
         SECTION("String, String") {
@@ -2391,7 +2408,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
 
             m = "-1";
             n = "2.5";
@@ -2399,7 +2416,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #2 to 'ult' (number has no integer representation)");
+                Contains("bad argument #2") && Contains("number has no integer representation"));
 
             m = "1.42";
             n = "-2";
@@ -2407,7 +2424,7 @@ TEST_CASE("math.ult(m, n)") {
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
                 minilua::math::ult(ctx),
-                "bad argument #1 to 'ult' (number has no integer representation)");
+                Contains("bad argument #1") && Contains("number has no integer representation"));
         }
     }
 
@@ -2418,13 +2435,15 @@ TEST_CASE("math.ult(m, n)") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(m), n});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::ult(ctx), "bad argument #1 to 'ult' (number expected, got string)");
+                minilua::math::ult(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
 
             n = "1";
             list = minilua::Vallist({minilua::Value(m), n});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::ult(ctx), "bad argument #1 to 'ult' (number expected, got string)");
+                minilua::math::ult(ctx),
+                Contains("bad argument #1") && Contains("number expected"));
         }
 
         SECTION("n is invalid") {
@@ -2433,7 +2452,8 @@ TEST_CASE("math.ult(m, n)") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(m), n});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::ult(ctx), "bad argument #2 to 'ult' (number expected, got string)");
+                minilua::math::ult(ctx),
+                Contains("bad argument #2") && Contains("number expected"));
         }
     }
 }

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -82,7 +82,7 @@ TEST_CASE("math.abs(x)") {
             minilua::Vallist list = minilua::Vallist({minilua::Value(i)});
             ctx = ctx.make_new(list);
             CHECK_THROWS_WITH(
-                minilua::math::abs(ctx), "bad argument #1 to 'abs' (number expected, got string)");
+                minilua::math::abs(ctx), "bad argument #1 (number expected, got string)");
         }
     }
 }

--- a/tests/math_tests.cpp
+++ b/tests/math_tests.cpp
@@ -2566,11 +2566,7 @@ TEST_CASE("reverse acos") {
 
             // force value to nan, directly insert nan doesn't work
             auto result = res.force(minilua::Value(std::asin(2)));
-            REQUIRE(result.has_value());
-
-            CHECK(
-                result.value().collect_first_alternative()[0] ==
-                minilua::SourceChange(minilua::Range(), "nan"));
+            REQUIRE(!result.has_value());
         }
     }
 
@@ -2657,11 +2653,7 @@ TEST_CASE("reverse asin") {
 
             // force value to nan, directly insert nan doesn't work
             auto result = res.force(minilua::Value(std::asin(2)));
-            REQUIRE(result.has_value());
-
-            CHECK(
-                result.value().collect_first_alternative()[0] ==
-                minilua::SourceChange(minilua::Range(), "nan"));
+            REQUIRE(!result.has_value());
         }
     }
 
@@ -2824,11 +2816,7 @@ TEST_CASE("reverse cos") {
             minilua::SourceChange(minilua::Range(), "1.5708"));
 
         result = res.force(3);
-        REQUIRE(result.has_value());
-
-        CHECK(
-            result.value().collect_first_alternative()[0] ==
-            minilua::SourceChange(minilua::Range(), "nan"));
+        REQUIRE(!result.has_value());
     }
 
     SECTION("invalid force") {
@@ -3147,13 +3135,6 @@ TEST_CASE("reverse sin") {
         CHECK(
             result.value().collect_first_alternative()[0] ==
             minilua::SourceChange(minilua::Range(), "1.5708"));
-
-        result = res.force(3);
-        REQUIRE(result.has_value());
-
-        CHECK(
-            result.value().collect_first_alternative()[0] ==
-            minilua::SourceChange(minilua::Range(), "nan"));
     }
 
     SECTION("invalid force") {
@@ -3168,6 +3149,9 @@ TEST_CASE("reverse sin") {
         // formated like a Number
         auto result = res.force("1");
         CHECK_FALSE(result.has_value());
+
+        result = res.force(3);
+        CHECK(!result.has_value());
     }
 }
 

--- a/tests/public_api/origin.cpp
+++ b/tests/public_api/origin.cpp
@@ -61,6 +61,7 @@ TEST_CASE("define correct origin for unary math functions and force value") {
     REQUIRE(res == 5);
 
     REQUIRE(res.has_origin());
+    INFO(res.origin());
     auto source_change_tree = res.force(3).value(); // NOLINT
     auto source_changes = source_change_tree.collect_first_alternative();
     CHECK(source_changes[0].replacement == "9.0");

--- a/tests/public_api/source_changes.cpp
+++ b/tests/public_api/source_changes.cpp
@@ -1,0 +1,68 @@
+#include "MiniLua/source_change.hpp"
+#include <catch2/catch.hpp>
+
+#include <MiniLua/MiniLua.hpp>
+
+TEST_CASE("Simplify SourceChangeTree") {
+    SECTION("empty tree") {
+        REQUIRE(minilua::simplify(std::nullopt) == std::nullopt);
+        REQUIRE(minilua::simplify(minilua::SourceChangeAlternative()) == std::nullopt);
+        REQUIRE(minilua::simplify(minilua::SourceChangeCombination()) == std::nullopt);
+    }
+
+    SECTION("nested empty tree") {
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeCombination(
+                {minilua::SourceChangeAlternative(),
+                 minilua::SourceChangeAlternative({minilua::SourceChangeCombination()})})) ==
+            std::nullopt);
+
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeCombination({
+                minilua::SourceChangeAlternative(),
+                minilua::SourceChangeAlternative(),
+                minilua::SourceChangeAlternative(),
+                minilua::SourceChangeAlternative(),
+            })) == std::nullopt);
+    }
+
+    SECTION("simple one item tree") {
+        REQUIRE(
+            minilua::simplify(minilua::SourceChange({{1, 2, 3}}, "123")) ==
+            minilua::SourceChange({{1, 2, 3}}, "123"));
+    }
+
+    SECTION("nested single items") {
+        const auto item = minilua::SourceChange({{1, 2, 3}, {4, 5, 6}}, "123");
+
+        REQUIRE(minilua::simplify(minilua::SourceChangeAlternative({item})) == item);
+        REQUIRE(minilua::simplify(minilua::SourceChangeCombination({item})) == item);
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeAlternative(
+                {minilua::SourceChangeAlternative({item})})) == item);
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeCombination(
+                {minilua::SourceChangeAlternative({item})})) == item);
+    }
+
+    SECTION("multiple nested items") {
+        const auto item1 = minilua::SourceChange({{1, 2, 3}, {4, 5, 6}}, "123");
+        const auto item2 = minilua::SourceChange({{7, 8, 9}, {8, 9, 9}}, "abc");
+
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeAlternative({item1, item2})) ==
+            minilua::SourceChangeAlternative({item1, item2}));
+
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeAlternative({
+                minilua::SourceChangeAlternative({item1}),
+                minilua::SourceChangeAlternative({item2}),
+            })) == minilua::SourceChangeAlternative({item1, item2}));
+
+        REQUIRE(
+            minilua::simplify(minilua::SourceChangeCombination({
+                minilua::SourceChangeAlternative({item1}),
+                minilua::SourceChangeAlternative({item2}),
+            })) == minilua::SourceChangeCombination({item1, item2}));
+    }
+}


### PR DESCRIPTION
- Make *NumericFunctionHelper more generic
- Fix Value::to_number for number arguments, etc
- Relax exception tests for math functions
- Use *NumberFunctionHelper in math lib
- Filter out nan and infinite values in reverse
- Simplify SourceChangeTree and Origins

This also works towards #118 
