### PR TITLE
Don't return functions from the interpreter

### DIFF
--- a/include/MiniLua/values.hpp
+++ b/include/MiniLua/values.hpp
@@ -609,6 +609,11 @@ public:
     [[nodiscard]] auto border() const -> int;
 
     /**
+     * Checks if the table contains a Function.
+     */
+    [[nodiscard]] auto contains_function() const -> bool;
+
+    /**
      * @brief Try to get the value with the given key.
      *
      * If the value does not exist this will return `Nil`.
@@ -1480,6 +1485,11 @@ public:
      * @brief Check if the value is a Function.
      */
     [[nodiscard]] auto is_function() const -> bool;
+
+    /**
+     * @brief Check if the value is or contains a Function.
+     */
+    [[nodiscard]] auto contains_function() const -> bool;
 
     /**
      * @brief Check if the value has an Origin.

--- a/src/details/interpreter.cpp
+++ b/src/details/interpreter.cpp
@@ -99,7 +99,24 @@ auto Interpreter::run(const ts::Tree& tree, Env& user_env) -> EvalResult {
     // execute the actual program
     std::shared_ptr<std::string> root_filename = std::make_shared<std::string>("__root__");
     env.set_file(root_filename);
-    return this->run_file(tree, env);
+
+    auto result = this->run_file(tree, env);
+
+    if (result.values.size() != 0) {
+        // don't return functions (or tables that contains functions)
+        // this prevents crashes because it is not allwed to call lua functions
+        // after the interpreter finishes
+        //
+        // also ignore everything except the first value because the public api
+        // only returns one value
+        if (result.values.get(0).contains_function()) {
+            result.values = Vallist();
+        } else {
+            result.values = Vallist(result.values.get(0));
+        }
+    }
+
+    return result;
 }
 
 auto Interpreter::setup_environment(Env& user_env) -> Env {

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -150,6 +150,11 @@ void swap(Table& self, Table& other) {
 
 auto Table::border() const -> int { return this->impl->calc_border(); }
 
+auto Table::contains_function() const -> bool {
+    return std::any_of(
+        this->begin(), this->end(), [](const auto& kv) { return kv.second.is_function(); });
+}
+
 auto Table::get(const Value& key) -> Value {
     auto value = impl->value.find(key);
     if (value == impl->value.end()) {

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -610,6 +610,15 @@ auto Value::raw() const -> const Value::Type& { return impl->val; }
 [[nodiscard]] auto Value::is_function() const -> bool {
     return std::holds_alternative<Function>(this->raw());
 }
+auto Value::contains_function() const -> bool {
+    if (this->is_function()) {
+        return true;
+    } else if (this->is_table()) {
+        return std::get<Table>(*this).contains_function();
+    } else {
+        return false;
+    }
+}
 
 [[nodiscard]] auto Value::has_origin() const -> bool { return !this->impl->origin.is_none(); }
 

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -140,6 +140,22 @@ TEST_CASE("unit_tests lua files") {
     }
 }
 
+TEST_CASE("interpreter does not return functions") {
+    SECTION("plain function") {
+        minilua::Interpreter interpreter;
+        interpreter.parse("return print");
+        auto result = interpreter.evaluate();
+        REQUIRE(result.value.is_nil());
+    }
+
+    SECTION("function in table") {
+        minilua::Interpreter interpreter;
+        interpreter.parse(R"(return {print = print})");
+        auto result = interpreter.evaluate();
+        REQUIRE(result.value.is_nil());
+    }
+}
+
 TEST_CASE("whole lua-programs", "[.hide]") {
     SECTION("programs with function calls") {
         std::vector<std::string> test_files{


### PR DESCRIPTION
Fixes #110 

Calling lua functions after the interpreter finishes running will crash.