### PR TITLE
Don't allow Nil as table key

### DIFF
--- a/src/table.cpp
+++ b/src/table.cpp
@@ -113,20 +113,20 @@ Table::Table(MemoryAllocator* allocator)
 Table::Table(std::unordered_map<Value, Value> values, MemoryAllocator* allocator)
     : Table(allocator) {
     for (const auto& [key, value] : values) {
-        this->impl->value.insert_or_assign(key, value);
+        this->set(key, value);
     }
 }
 Table::Table(
     std::initializer_list<std::pair<const Value, Value>> values, MemoryAllocator* allocator)
     : Table(allocator) {
     for (const auto& [key, value] : values) {
-        this->impl->value.insert_or_assign(key, value);
+        this->set(key, value);
     }
 }
 
 Table::Table(const Table& other, MemoryAllocator* allocator) : Table(allocator) {
     for (const auto& [key, value] : other) {
-        this->impl->value.insert_or_assign(Value(key, allocator), Value(value, allocator));
+        this->set(Value(key, allocator), Value(value, allocator));
     }
 }
 
@@ -159,8 +159,18 @@ auto Table::get(const Value& key) -> Value {
     }
 }
 auto Table::has(const Value& key) -> bool { return impl->value.find(key) != impl->value.end(); }
-void Table::set(const Value& key, Value value) { impl->set(key, std::move(value)); }
-void Table::set(Value&& key, Value value) { impl->set(key, std::move(value)); }
+void Table::set(const Value& key, Value value) {
+    if (key.is_nil()) {
+        throw std::runtime_error("table index is nil");
+    }
+    impl->set(key, std::move(value));
+}
+void Table::set(Value&& key, Value value) {
+    if (key.is_nil()) {
+        throw std::runtime_error("table index is nil");
+    }
+    impl->set(key, std::move(value));
+}
 void Table::set_all(const Table& other) {
     for (const auto& [key, value] : other) {
         this->set(key, value);

--- a/tests/public_api/values.cpp
+++ b/tests/public_api/values.cpp
@@ -304,6 +304,19 @@ TEST_CASE("table is iterable") {
     }
 }
 
+TEST_CASE("nil keys are not allowed") {
+    CHECK_THROWS(minilua::Table{{minilua::Nil(), 22}});
+    CHECK_THROWS(minilua::Table({{minilua::Nil(), 22}}));
+    CHECK_THROWS(
+        minilua::Table(std::unordered_map<minilua::Value, minilua::Value>{{minilua::Nil(), 22}}));
+
+    minilua::Table table;
+    CHECK_THROWS(table.set(minilua::Nil(), 22));
+
+    minilua::Value key = minilua::Nil();
+    CHECK_THROWS(table.set(key, 22));
+}
+
 TEST_CASE("function Value is constructable") {
     static_assert(std::is_nothrow_move_constructible<minilua::Function>());
     static_assert(std::is_nothrow_move_assignable<minilua::Function>());


### PR DESCRIPTION
Fixes #61 

Setting or creating a table with a Nil key will now throw an exception