### PR TITLE
Initial testing harness for lua files

### DIFF
--- a/include/MiniLua/stdlib.hpp
+++ b/include/MiniLua/stdlib.hpp
@@ -32,9 +32,9 @@ void error(const CallContext& ctx);
  * Calls the given function (first argument) with the given arguments (rest of
  * the arguments) and catches any errors.
  *
- * If the function raise an error this function returns two values: `true` and
+ * If the function raise an error this function returns two values: `false` and
  * the error message. If the function does not raise an error this function will
- * return `false` and all return values of the called functions.
+ * return `true` and all return values of the called functions.
  *
  * \note The source changes from a called function will only be forwarded if no error
  * was raised.

--- a/include/MiniLua/stdlib.hpp
+++ b/include/MiniLua/stdlib.hpp
@@ -26,6 +26,28 @@ auto force(const CallContext& ctx) -> CallResult;
 
 void error(const CallContext& ctx);
 
+/**
+ * @brief Calls the given function with the given arguments and catches errors.
+ *
+ * Calls the given function (first argument) with the given arguments (rest of
+ * the arguments) and catches any errors.
+ *
+ * If the function raise an error this function returns two values: `true` and
+ * the error message. If the function does not raise an error this function will
+ * return `true` and all return values of the called functions.
+ *
+ * \note The source changes from a called function will only be forwarded if no error
+ * was raised.
+ */
+auto pcall(const CallContext& ctx) -> CallResult;
+
+/**
+ * @brief Converts the value to a string.
+ *
+ * Tables and functions will not return a meaningful string.
+ *
+ * Will respect the metamethod `__tostring`.
+ */
 auto to_string(const CallContext& ctx) -> Value;
 
 auto to_number(const CallContext& ctx) -> Value;

--- a/include/MiniLua/stdlib.hpp
+++ b/include/MiniLua/stdlib.hpp
@@ -34,7 +34,7 @@ void error(const CallContext& ctx);
  *
  * If the function raise an error this function returns two values: `true` and
  * the error message. If the function does not raise an error this function will
- * return `true` and all return values of the called functions.
+ * return `false` and all return values of the called functions.
  *
  * \note The source changes from a called function will only be forwarded if no error
  * was raised.

--- a/luaprograms/unit_tests/assert.lua
+++ b/luaprograms/unit_tests/assert.lua
@@ -1,2 +1,3 @@
 assert(true)
-assert(false, "message")
+
+assert(not pcall(function () assert(false, "message") end))

--- a/luaprograms/unit_tests/source_changes/1.lua
+++ b/luaprograms/unit_tests/source_changes/1.lua
@@ -1,0 +1,1 @@
+force(2, 7) -- EXPECT SOURCE_CHANGE 1:7 7

--- a/luaprograms/unit_tests/source_changes/2.lua
+++ b/luaprograms/unit_tests/source_changes/2.lua
@@ -1,0 +1,1 @@
+force("hi", "replacement") -- EXPECT SOURCE_CHANGE 1:7 "replacement"

--- a/luaprograms/unit_tests/source_changes/3.lua
+++ b/luaprograms/unit_tests/source_changes/3.lua
@@ -1,0 +1,1 @@
+force(tonumber("5") + 1, 7) -- EXPECT SOURCE_CHANGE 1:16 "6"

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "MiniLua/environment.hpp"
+#include "MiniLua/interpreter.hpp"
+#include "MiniLua/source_change.hpp"
 #include "MiniLua/stdlib.hpp"
 #include "MiniLua/utils.hpp"
 #include "internal_env.hpp"
@@ -58,6 +60,9 @@ void add_stdlib(Table& table) {
     table.set("select", select);
     table.set("print", print);
     table.set("error", error);
+    table.set("pcall", pcall);
+
+    // non official lua stdlib items
     table.set("discard_origin", discard_origin);
 }
 
@@ -67,6 +72,31 @@ void error(const CallContext& ctx) {
     // TODO implement level (we need a proper call stack for that)
     auto message = ctx.arguments().get(0);
     throw std::runtime_error(std::get<String>(message.to_string()).value);
+}
+
+auto pcall(const CallContext& ctx) -> CallResult {
+    // function to call
+    auto fun = ctx.arguments().get(0);
+
+    // rest of the arguments
+    std::vector<Value> args;
+    args.reserve(ctx.arguments().size() - 1);
+    std::move(ctx.arguments().begin() + 1, ctx.arguments().end(), std::back_inserter(args));
+
+    try {
+        auto call_result = fun.call(ctx.make_new(args));
+
+        // collect return values and put `true` in front of them
+        std::vector<Value> values;
+        values.reserve(call_result.values().size() + 1);
+        values.emplace_back(true);
+        std::move(
+            call_result.values().begin(), call_result.values().end(), std::back_inserter(values));
+
+        return CallResult(values, call_result.source_change());
+    } catch (const InterpreterException& e) {
+        return CallResult({false, String(e.what())});
+    }
 }
 
 auto to_string(const CallContext& ctx) -> Value {

--- a/src/stdlib.cpp
+++ b/src/stdlib.cpp
@@ -54,7 +54,7 @@ namespace details {
 
 void add_stdlib(Table& table) {
     table.set("tostring", to_string);
-    table.set("to_number", to_number);
+    table.set("tonumber", to_number);
     table.set("type", type);
     table.set("next", next);
     table.set("select", select);
@@ -64,6 +64,7 @@ void add_stdlib(Table& table) {
 
     // non official lua stdlib items
     table.set("discard_origin", discard_origin);
+    table.set("force", force);
 }
 
 } // namespace details

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(MiniLua-tests
     unit_tests.cpp
     integration_tests.cpp
     lua_tests.cpp
+    lua_test_driver.cpp
     public_api/integration_tests.cpp
     public_api/owning_ptr.cpp
     public_api/values.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(MiniLua-tests
     main.cpp
     unit_tests.cpp
     integration_tests.cpp
+    lua_tests.cpp
     public_api/integration_tests.cpp
     public_api/owning_ptr.cpp
     public_api/values.cpp

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -67,13 +67,6 @@ std::string parse_eval_update(std::string program) {
     return program;
 }
 
-std::string read_input_from_file(std::string path) {
-    std::ifstream ifs;
-    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-    ifs.open(path);
-    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
-}
-
 // TODO fix the memory leaks
 TEST_CASE("parse, eval, update", "[parse][leaks]") {
     SECTION("simple for") {
@@ -95,51 +88,6 @@ TEST_CASE("parse, eval, update", "[parse][leaks]") {
     }
 }
 
-TEST_CASE("unit_tests lua files") {
-    std::vector<std::string> test_files{
-        "literals/bools.lua",
-        "literals/numbers.lua",
-        "literals/string.lua",
-        "literals/table.lua",
-        "expressions/binary_operations.lua",
-        "expressions/unary_operations.lua",
-        "statements/if.lua",
-        "statements/while.lua",
-        "statements/repeat_until.lua",
-        "statements/functions.lua",
-        "local_variables.lua",
-        "counter.lua",
-    };
-    // NOTE: exptects to be run from build directory
-    for (const auto& file : test_files) {
-        std::string path = "../luaprograms/unit_tests/" + file;
-        DYNAMIC_SECTION("File: " << path) {
-            // TODO remove once comments work
-            std::string program = read_input_from_file(path);
-
-            while (true) {
-                auto start_pos = program.find("--");
-                if (start_pos == std::string::npos) {
-                    break;
-                }
-
-                auto end_pos = program.find('\n', start_pos);
-                if (end_pos == std::string::npos) {
-                    end_pos = program.size() - 1;
-                }
-
-                auto count = end_pos - start_pos + 1;
-                program.replace(start_pos, count, "");
-            }
-
-            minilua::Interpreter interpreter;
-            REQUIRE(interpreter.parse(program));
-            auto result = interpreter.evaluate();
-            REQUIRE(!result.source_change.has_value());
-        }
-    }
-}
-
 TEST_CASE("interpreter does not return functions") {
     SECTION("plain function") {
         minilua::Interpreter interpreter;
@@ -156,41 +104,6 @@ TEST_CASE("interpreter does not return functions") {
     }
 }
 
-TEST_CASE("whole lua-programs", "[.hide]") {
-    SECTION("programs with function calls") {
-        std::vector<std::string> test_files{
-            "BepposBalloons.lua",
-            "FragmeentedFurniture.lua",
-            "FragmentedFurniture_withoutMethods.lua",
-            "HelplessHuman.lua",
-            "LottaLaps.lua",
-            "luaToStringFunctionExample.lua",
-            "simple.lua"};
-        for (const auto& file : test_files) {
-            std::string path = "../luaprograms/" + file;
-            DYNAMIC_SECTION("File: " << path) {
-                const std::string program = read_input_from_file(path);
-
-                // old parser
-                // const auto result = parse_eval_update(program);
-                // REQUIRE(result == program);
-
-                minilua::Interpreter interpreter;
-                // interpreter.config().all(true);
-                interpreter.parse(program);
-                auto result = interpreter.evaluate();
-                REQUIRE(!result.source_change.has_value());
-            }
-        }
-    }
-
-    SECTION("Lua-program without functions") {
-        const std::string program =
-            read_input_from_file("../luaprograms/FragmentedFurniture_withoutMethods.lua");
-        const auto result = parse_eval_update(program);
-        REQUIRE(result == program);
-    }
-}
 TEST_CASE("old Environment leaks", "[interpreter][leaks]") {
     static_assert(std::is_move_constructible<lua::rt::Environment>());
 

--- a/tests/lua_test_driver.cpp
+++ b/tests/lua_test_driver.cpp
@@ -1,0 +1,151 @@
+#include "lua_test_driver.hpp"
+
+#include <MiniLua/MiniLua.hpp>
+#include <catch2/catch.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <regex>
+
+auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self) -> std::ostream& {
+    o << "[";
+
+    const char* sep = " ";
+    for (const auto& change : self) {
+        o << sep << change;
+        sep = ", ";
+    }
+
+    return o << " ]";
+}
+
+auto read_input_from_file(const std::string& path) -> std::string {
+    std::ifstream ifs;
+    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    ifs.open(path);
+    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+}
+
+// struct ExpectedChange
+ExpectedChange::ExpectedChange(const std::smatch& match)
+    : row(stoul(match[1].str())), column(stoul(match[2].str())), replacement(match[3].str()) {}
+
+auto operator==(const ExpectedChange& expected, const minilua::SourceChange& actual) -> bool {
+    return actual.range.start.line + 1 == expected.row &&
+           actual.range.start.column + 1 == expected.column &&
+           actual.replacement == expected.replacement;
+}
+
+auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream& {
+    return o << "ExpectedChange{ " << self.row << ":" << self.column << " " << self.replacement
+             << " }";
+}
+
+static const std::string COMMENT_PREFIX = "-- EXPECT ";
+
+auto find_expect_strings(const std::string& source) -> std::vector<std::string> {
+    std::vector<std::string> expect_strings;
+
+    auto start_pos = 0;
+    while (start_pos != std::string::npos) {
+        start_pos = source.find(COMMENT_PREFIX, start_pos);
+        if (start_pos == std::string::npos) {
+            break;
+        }
+
+        start_pos = start_pos + COMMENT_PREFIX.length();
+
+        auto end_pos = source.find('\n', start_pos);
+        if (end_pos == std::string::npos) {
+            end_pos = source.size() - 1;
+        }
+
+        std::string expect_str = source.substr(start_pos, end_pos - start_pos);
+        expect_strings.push_back(expect_str);
+
+        start_pos = end_pos;
+    }
+
+    return expect_strings;
+}
+
+// struct BaseTest
+BaseTest::BaseTest(std::regex regex) : regex(std::move(regex)) {}
+auto BaseTest::expect_source_changes() -> bool { return false; }
+
+static const std::regex source_change_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
+
+// struct SourceChangeTest
+SourceChangeTest::SourceChangeTest() : BaseTest(source_change_regex) {}
+
+void SourceChangeTest::reset() { this->expected_changes.clear(); }
+void SourceChangeTest::collect_metadata(const std::string& str) {
+    std::smatch match;
+    if (std::regex_match(str, match, this->regex)) {
+        this->expected_changes.emplace_back(match);
+    }
+}
+
+auto SourceChangeTest::expect_source_changes() -> bool { return !expected_changes.empty(); }
+
+void SourceChangeTest::run(const minilua::EvalResult& result) {
+    CAPTURE(result);
+    CAPTURE(expected_changes);
+
+    // if we found source change tests we require to get source changes
+    if (expected_changes.empty()) {
+        CAPTURE(result.source_change);
+        REQUIRE(!result.source_change.has_value());
+    } else {
+        REQUIRE(result.source_change.has_value());
+        // check that the expected source changes are in the actual source
+        // changes
+        std::vector<minilua::SourceChange> actual_changes;
+        result.source_change.value().visit_all(
+            [&actual_changes](const auto& c) { actual_changes.push_back(c); });
+
+        CAPTURE(actual_changes);
+
+        for (const auto& expected_change : expected_changes) {
+            bool is_in_actual_changes = any_of(actual_changes, expected_change);
+            if (!is_in_actual_changes) {
+                CAPTURE(expected_change);
+                FAIL("Could not find expected_change in actual_changes");
+            }
+        }
+    }
+}
+
+static std::vector<std::unique_ptr<BaseTest>> tests;
+auto get_tests() -> std::vector<std::unique_ptr<BaseTest>>& { return tests; }
+
+void register_test(BaseTest* test) { tests.push_back(std::unique_ptr<BaseTest>(test)); }
+
+void test_file(const std::string& file) {
+    std::string program = read_input_from_file(file);
+
+    auto expect_strings = find_expect_strings(program);
+
+    // setup tests
+    auto& tests = get_tests();
+    for (auto& test : tests) {
+        test->reset();
+        for (const auto& str : expect_strings) {
+            test->collect_metadata(str);
+        }
+    }
+
+    // parse
+    minilua::Interpreter interpreter;
+    auto parse_result = interpreter.parse(program);
+    CAPTURE(parse_result.errors);
+    REQUIRE(parse_result);
+
+    // evaluate
+    auto result = interpreter.evaluate();
+
+    // check
+    for (auto& test : tests) {
+        test->run(result);
+    }
+}

--- a/tests/lua_test_driver.cpp
+++ b/tests/lua_test_driver.cpp
@@ -73,49 +73,6 @@ auto find_expect_strings(const std::string& source) -> std::vector<std::string> 
 BaseTest::BaseTest(std::regex regex) : regex(std::move(regex)) {}
 auto BaseTest::expect_source_changes() -> bool { return false; }
 
-static const std::regex source_change_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
-
-// struct SourceChangeTest
-SourceChangeTest::SourceChangeTest() : BaseTest(source_change_regex) {}
-
-void SourceChangeTest::reset() { this->expected_changes.clear(); }
-void SourceChangeTest::collect_metadata(const std::string& str) {
-    std::smatch match;
-    if (std::regex_match(str, match, this->regex)) {
-        this->expected_changes.emplace_back(match);
-    }
-}
-
-auto SourceChangeTest::expect_source_changes() -> bool { return !expected_changes.empty(); }
-
-void SourceChangeTest::run(const minilua::EvalResult& result) {
-    CAPTURE(result);
-    CAPTURE(expected_changes);
-
-    // if we found source change tests we require to get source changes
-    if (expected_changes.empty()) {
-        CAPTURE(result.source_change);
-        REQUIRE(!result.source_change.has_value());
-    } else {
-        REQUIRE(result.source_change.has_value());
-        // check that the expected source changes are in the actual source
-        // changes
-        std::vector<minilua::SourceChange> actual_changes;
-        result.source_change.value().visit_all(
-            [&actual_changes](const auto& c) { actual_changes.push_back(c); });
-
-        CAPTURE(actual_changes);
-
-        for (const auto& expected_change : expected_changes) {
-            bool is_in_actual_changes = any_of(actual_changes, expected_change);
-            if (!is_in_actual_changes) {
-                CAPTURE(expected_change);
-                FAIL("Could not find expected_change in actual_changes");
-            }
-        }
-    }
-}
-
 static std::vector<std::unique_ptr<BaseTest>> tests;
 auto get_tests() -> std::vector<std::unique_ptr<BaseTest>>& { return tests; }
 

--- a/tests/lua_test_driver.hpp
+++ b/tests/lua_test_driver.hpp
@@ -77,30 +77,6 @@ struct BaseTest {
     virtual auto expect_source_changes() -> bool;
 };
 
-/**
- * Expect a source change.
- *
- * ```lua
- * -- EXPECT SOURCE_CHANGE <row>:<col> <replacement>
- * -- EXPECT SOURCE_CHANGE 2:7 25
- * -- EXPECT SOURCE_CHANGE 2:7 "string"
- * ```
- */
-struct SourceChangeTest : BaseTest {
-    std::vector<ExpectedChange> expected_changes;
-
-    SourceChangeTest();
-    ~SourceChangeTest() override = default;
-
-    void reset() override;
-
-    void collect_metadata(const std::string& str) override;
-
-    auto expect_source_changes() -> bool override;
-
-    void run(const minilua::EvalResult& result) override;
-};
-
 auto get_tests() -> std::vector<std::unique_ptr<BaseTest>>&;
 void register_test(BaseTest* test);
 

--- a/tests/lua_test_driver.hpp
+++ b/tests/lua_test_driver.hpp
@@ -1,0 +1,109 @@
+#ifndef TESTS_LUA_TEST_DRIVER_HPP
+#define TESTS_LUA_TEST_DRIVER_HPP
+
+#include <MiniLua/MiniLua.hpp>
+#include <catch2/catch.hpp>
+
+#include <iostream>
+#include <regex>
+
+auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self) -> std::ostream&;
+
+auto read_input_from_file(const std::string& path) -> std::string;
+
+/**
+ * Represents the following line in a lua file:
+ *
+ * ```lua
+ * -- EXPECT SOURCE_CHANGE <row>:<column> <replacement>
+ * ```
+ */
+struct ExpectedChange {
+    size_t row;
+    size_t column;
+    std::string replacement;
+
+    ExpectedChange(const std::smatch& match);
+};
+
+auto operator==(const ExpectedChange& expected, const minilua::SourceChange& actual) -> bool;
+
+auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream&;
+
+/**
+ * Search for comments of the form:
+ *
+ * ```lua
+ * -- EXPECT <something>
+ * ```
+ */
+auto find_expect_strings(const std::string& source) -> std::vector<std::string>;
+
+template <typename Iterable, typename Item>
+auto any_of(const Iterable& iterable, const Item& item) -> bool {
+    return std::any_of(
+        iterable.cbegin(), iterable.cend(), [item](const auto& actual) { return item == actual; });
+}
+
+/**
+ * Base class for "-- EXPECT" test cases in lua files.
+ *
+ * Usage:
+ *
+ * - setup
+ *   - first call reset
+ *   - then call collect_metadata on every substring of a comment
+ *     (the part after the "-- EXPECT")
+ * - check
+ *   - then call run using the result of evaluating the program
+ */
+struct BaseTest {
+    std::regex regex;
+
+    BaseTest(std::regex regex);
+    virtual ~BaseTest() = default;
+
+    virtual void reset() = 0;
+
+    virtual void collect_metadata(const std::string& str) = 0;
+
+    virtual void run(const minilua::EvalResult& result) = 0;
+
+    /**
+     * Returns false by default.
+     *
+     * Only override if you (always or conditionally) expect source changes.
+     */
+    virtual auto expect_source_changes() -> bool;
+};
+
+/**
+ * Expect a source change.
+ *
+ * ```lua
+ * -- EXPECT SOURCE_CHANGE <row>:<col> <replacement>
+ * -- EXPECT SOURCE_CHANGE 2:7 25
+ * -- EXPECT SOURCE_CHANGE 2:7 "string"
+ * ```
+ */
+struct SourceChangeTest : BaseTest {
+    std::vector<ExpectedChange> expected_changes;
+
+    SourceChangeTest();
+    ~SourceChangeTest() override = default;
+
+    void reset() override;
+
+    void collect_metadata(const std::string& str) override;
+
+    auto expect_source_changes() -> bool override;
+
+    void run(const minilua::EvalResult& result) override;
+};
+
+auto get_tests() -> std::vector<std::unique_ptr<BaseTest>>&;
+void register_test(BaseTest* test);
+
+void test_file(const std::string& file);
+
+#endif

--- a/tests/lua_tests.cpp
+++ b/tests/lua_tests.cpp
@@ -26,6 +26,63 @@ static auto ftw_callback(const char* fpath, const struct stat* /*sb*/, int typef
     return 0;
 }
 
+static const std::regex source_change_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
+
+/**
+ * Expect a source change.
+ *
+ * ```lua
+ * -- EXPECT SOURCE_CHANGE <row>:<col> <replacement>
+ * -- EXPECT SOURCE_CHANGE 2:7 25
+ * -- EXPECT SOURCE_CHANGE 2:7 "string"
+ * ```
+ */
+struct SourceChangeTest : BaseTest {
+    std::vector<ExpectedChange> expected_changes;
+
+    SourceChangeTest() : BaseTest(source_change_regex) {}
+    ~SourceChangeTest() override = default;
+
+    void reset() override { this->expected_changes.clear(); }
+
+    void collect_metadata(const std::string& str) override {
+        std::smatch match;
+        if (std::regex_match(str, match, this->regex)) {
+            this->expected_changes.emplace_back(match);
+        }
+    }
+
+    auto expect_source_changes() -> bool override { return !expected_changes.empty(); }
+
+    void run(const minilua::EvalResult& result) override {
+        CAPTURE(result);
+        CAPTURE(expected_changes);
+
+        // if we found source change tests we require to get source changes
+        if (expected_changes.empty()) {
+            CAPTURE(result.source_change);
+            REQUIRE(!result.source_change.has_value());
+        } else {
+            REQUIRE(result.source_change.has_value());
+            // check that the expected source changes are in the actual source
+            // changes
+            std::vector<minilua::SourceChange> actual_changes;
+            result.source_change.value().visit_all(
+                [&actual_changes](const auto& c) { actual_changes.push_back(c); });
+
+            CAPTURE(actual_changes);
+
+            for (const auto& expected_change : expected_changes) {
+                bool is_in_actual_changes = any_of(actual_changes, expected_change);
+                if (!is_in_actual_changes) {
+                    CAPTURE(expected_change);
+                    FAIL("Could not find expected_change in actual_changes");
+                }
+            }
+        }
+    }
+};
+
 TEST_CASE("lua file tests") {
     // collect files to test
     ftw(DIR, ftw_callback, 16); // NOLINT(readability-magic-numbers)

--- a/tests/lua_tests.cpp
+++ b/tests/lua_tests.cpp
@@ -1,0 +1,128 @@
+#include "MiniLua/source_change.hpp"
+#include <algorithm>
+#include <catch2/catch.hpp>
+#include <fnmatch.h>
+#include <fstream>
+#include <ftw.h>
+#include <map>
+
+#include <MiniLua/MiniLua.hpp>
+#include <regex>
+#include <string>
+
+static const char* DIR = "../luaprograms/unit_tests/";
+
+static std::vector<std::string> test_files;
+
+static auto ftw_callback(const char* fpath, const struct stat* /*sb*/, int typeflag) -> int {
+    if (typeflag == FTW_F) {
+        if (fnmatch("*.lua", fpath, FNM_CASEFOLD) == 0) {
+            test_files.emplace_back(fpath);
+        }
+    }
+
+    // tell ftw to continue
+    return 0;
+}
+
+static auto read_input_from_file(const std::string& path) -> std::string {
+    std::ifstream ifs;
+    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    ifs.open(path);
+    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+}
+
+struct ExpectedChange {
+    int row;
+    int column;
+    std::string replacement;
+};
+
+static auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream& {
+    return o << "ExpectedChange{ .row = " << self.row << ", .column = " << self.column
+             << ", .replacement = " << self.replacement << " }";
+}
+
+static auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self)
+    -> std::ostream& {
+    o << "[";
+
+    const char* sep = " ";
+    for (const auto& change : self) {
+        o << sep << change;
+        sep = ", ";
+    }
+
+    return o << " ]";
+}
+
+TEST_CASE("unit_tests lua files") {
+    ftw(DIR, ftw_callback, 16); // NOLINT(readability-magic-numbers)
+
+    // NOTE: expects to be run from build directory
+    for (const auto& file : test_files) {
+        DYNAMIC_SECTION("File: " << file) {
+            std::string program = read_input_from_file(file);
+
+            std::vector<ExpectedChange> expected_changes;
+
+            auto start_pos = 0;
+            while (start_pos != std::string::npos) {
+                start_pos = program.find("-- EXPECT ", start_pos);
+                if (start_pos == std::string::npos) {
+                    break;
+                }
+
+                start_pos = start_pos + 10;
+
+                auto end_pos = program.find('\n', start_pos);
+                if (end_pos == std::string::npos) {
+                    end_pos = program.size() - 1;
+                }
+
+                std::string expect_str = program.substr(start_pos, end_pos - start_pos);
+
+                start_pos = end_pos;
+
+                std::regex expect_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
+                std::smatch match;
+
+                if (std::regex_match(expect_str, match, expect_regex)) {
+                    ExpectedChange e{
+                        .row = std::stoi(match[1].str()),
+                        .column = std::stoi(match[2].str()),
+                        .replacement = match[3].str(),
+                    };
+
+                    expected_changes.push_back(e);
+                }
+            }
+
+            minilua::Interpreter interpreter;
+            REQUIRE(interpreter.parse(program));
+            auto result = interpreter.evaluate();
+
+            if (expected_changes.empty()) {
+                REQUIRE(!result.source_change.has_value());
+            } else {
+                std::vector<minilua::SourceChange> actual_changes;
+                result.source_change.value().visit_all(
+                    [&actual_changes](const auto& c) { actual_changes.push_back(c); });
+
+                INFO(&actual_changes);
+
+                for (const auto& expected_change : expected_changes) {
+                    if (!std::any_of(
+                            actual_changes.begin(), actual_changes.end(),
+                            [&expected_change](const auto& change) {
+                                return change.range.start.line + 1 == expected_change.row &&
+                                       change.range.start.column + 1 == expected_change.column &&
+                                       change.replacement == expected_change.replacement;
+                            })) {
+                        FAIL("Could not find expected change " << expected_change);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/lua_tests.cpp
+++ b/tests/lua_tests.cpp
@@ -25,26 +25,7 @@ static auto ftw_callback(const char* fpath, const struct stat* /*sb*/, int typef
     return 0;
 }
 
-static auto read_input_from_file(const std::string& path) -> std::string {
-    std::ifstream ifs;
-    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-    ifs.open(path);
-    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
-}
-
-struct ExpectedChange {
-    int row;
-    int column;
-    std::string replacement;
-};
-
-static auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream& {
-    return o << "ExpectedChange{ .row = " << self.row << ", .column = " << self.column
-             << ", .replacement = " << self.replacement << " }";
-}
-
-static auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self)
-    -> std::ostream& {
+auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self) -> std::ostream& {
     o << "[";
 
     const char* sep = " ";
@@ -56,73 +37,136 @@ static auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>
     return o << " ]";
 }
 
-TEST_CASE("unit_tests lua files") {
+static auto read_input_from_file(const std::string& path) -> std::string {
+    std::ifstream ifs;
+    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    ifs.open(path);
+    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+}
+
+/**
+ * Represents the following line in a lua file:
+ *
+ * ```lua
+ * -- EXPECT SOURCE_CHANGE <row>:<column> <replacement>
+ * ```
+ */
+struct ExpectedChange {
+    size_t row;
+    size_t column;
+    std::string replacement;
+
+    ExpectedChange(const std::smatch& match)
+        : row(stoul(match[1].str())), column(stoul(match[2].str())), replacement(match[3].str()) {}
+};
+
+auto operator==(const ExpectedChange& expected, const minilua::SourceChange& actual) -> bool {
+    return actual.range.start.line + 1 == expected.row &&
+           actual.range.start.column + 1 == expected.column &&
+           actual.replacement == expected.replacement;
+}
+
+auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream& {
+    return o << "ExpectedChange{ .row = " << self.row << ", .column = " << self.column
+             << ", .replacement = " << self.replacement << " }";
+}
+
+static const std::string COMMENT_PREFIX = "-- EXPECT ";
+
+/**
+ * Search for comments of the form:
+ *
+ * ```lua
+ * -- EXPECT <something>
+ * ```
+ */
+auto find_expect_strings(const std::string& source) -> std::vector<std::string> {
+    std::vector<std::string> expect_strings;
+
+    auto start_pos = 0;
+    while (start_pos != std::string::npos) {
+        start_pos = source.find(COMMENT_PREFIX, start_pos);
+        if (start_pos == std::string::npos) {
+            break;
+        }
+
+        start_pos = start_pos + COMMENT_PREFIX.length();
+
+        auto end_pos = source.find('\n', start_pos);
+        if (end_pos == std::string::npos) {
+            end_pos = source.size() - 1;
+        }
+
+        std::string expect_str = source.substr(start_pos, end_pos - start_pos);
+        expect_strings.push_back(expect_str);
+
+        start_pos = end_pos;
+    }
+
+    return expect_strings;
+}
+
+static const std::regex source_change_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
+
+template <typename Iterable, typename Item>
+auto any_of(const Iterable& iterable, const Item& item) -> bool {
+    return std::any_of(
+        iterable.cbegin(), iterable.cend(), [item](const auto& actual) { return item == actual; });
+}
+
+void test_file(const std::string& file) {
+    std::string program = read_input_from_file(file);
+
+    auto expect_strings = find_expect_strings(program);
+
+    std::vector<ExpectedChange> expected_changes;
+
+    std::smatch match;
+    for (const auto& expect_str : expect_strings) {
+        if (std::regex_match(expect_str, match, source_change_regex)) {
+            ExpectedChange e(match);
+
+            expected_changes.push_back(e);
+        }
+        // TODO other expect kinds
+    }
+
+    // parse
+    minilua::Interpreter interpreter;
+    auto parse_result = interpreter.parse(program);
+    CAPTURE(parse_result.errors);
+    REQUIRE(parse_result);
+
+    // evaluate
+    auto result = interpreter.evaluate();
+
+    // check
+    if (expected_changes.empty()) {
+        CAPTURE(result.source_change);
+        REQUIRE(!result.source_change.has_value());
+    } else {
+        std::vector<minilua::SourceChange> actual_changes;
+        result.source_change.value().visit_all(
+            [&actual_changes](const auto& c) { actual_changes.push_back(c); });
+
+        CAPTURE(actual_changes);
+
+        for (const auto& expected_change : expected_changes) {
+            bool is_in_actual_changes = any_of(actual_changes, expected_change);
+            if (!is_in_actual_changes) {
+                CAPTURE(expected_change);
+                FAIL("Could not find expected_change in actual_changes");
+            }
+        }
+    }
+}
+
+TEST_CASE("lua file tests") {
+    // collect files to test
     ftw(DIR, ftw_callback, 16); // NOLINT(readability-magic-numbers)
 
     // NOTE: expects to be run from build directory
     for (const auto& file : test_files) {
-        DYNAMIC_SECTION("File: " << file) {
-            std::string program = read_input_from_file(file);
-
-            std::vector<ExpectedChange> expected_changes;
-
-            auto start_pos = 0;
-            while (start_pos != std::string::npos) {
-                start_pos = program.find("-- EXPECT ", start_pos);
-                if (start_pos == std::string::npos) {
-                    break;
-                }
-
-                start_pos = start_pos + 10;
-
-                auto end_pos = program.find('\n', start_pos);
-                if (end_pos == std::string::npos) {
-                    end_pos = program.size() - 1;
-                }
-
-                std::string expect_str = program.substr(start_pos, end_pos - start_pos);
-
-                start_pos = end_pos;
-
-                std::regex expect_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
-                std::smatch match;
-
-                if (std::regex_match(expect_str, match, expect_regex)) {
-                    ExpectedChange e{
-                        .row = std::stoi(match[1].str()),
-                        .column = std::stoi(match[2].str()),
-                        .replacement = match[3].str(),
-                    };
-
-                    expected_changes.push_back(e);
-                }
-            }
-
-            minilua::Interpreter interpreter;
-            REQUIRE(interpreter.parse(program));
-            auto result = interpreter.evaluate();
-
-            if (expected_changes.empty()) {
-                REQUIRE(!result.source_change.has_value());
-            } else {
-                std::vector<minilua::SourceChange> actual_changes;
-                result.source_change.value().visit_all(
-                    [&actual_changes](const auto& c) { actual_changes.push_back(c); });
-
-                INFO(&actual_changes);
-
-                for (const auto& expected_change : expected_changes) {
-                    if (!std::any_of(
-                            actual_changes.begin(), actual_changes.end(),
-                            [&expected_change](const auto& change) {
-                                return change.range.start.line + 1 == expected_change.row &&
-                                       change.range.start.column + 1 == expected_change.column &&
-                                       change.replacement == expected_change.replacement;
-                            })) {
-                        FAIL("Could not find expected change " << expected_change);
-                    }
-                }
-            }
-        }
+        DYNAMIC_SECTION("File: " << file) { test_file(file); }
     }
 }

--- a/tests/lua_tests.cpp
+++ b/tests/lua_tests.cpp
@@ -1,15 +1,15 @@
-#include "MiniLua/source_change.hpp"
-#include <algorithm>
+#include <MiniLua/MiniLua.hpp>
 #include <catch2/catch.hpp>
+
+#include <algorithm>
 #include <fnmatch.h>
 #include <fstream>
 #include <ftw.h>
 #include <map>
-
-#include <MiniLua/MiniLua.hpp>
-#include <regex>
 #include <string>
 #include <utility>
+
+#include "lua_test_driver.hpp"
 
 static const char* DIR = "../luaprograms/unit_tests/";
 
@@ -26,189 +26,12 @@ static auto ftw_callback(const char* fpath, const struct stat* /*sb*/, int typef
     return 0;
 }
 
-auto operator<<(std::ostream& o, const std::vector<minilua::SourceChange>& self) -> std::ostream& {
-    o << "[";
-
-    const char* sep = " ";
-    for (const auto& change : self) {
-        o << sep << change;
-        sep = ", ";
-    }
-
-    return o << " ]";
-}
-
-static auto read_input_from_file(const std::string& path) -> std::string {
-    std::ifstream ifs;
-    ifs.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-    ifs.open(path);
-    return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
-}
-
-/**
- * Represents the following line in a lua file:
- *
- * ```lua
- * -- EXPECT SOURCE_CHANGE <row>:<column> <replacement>
- * ```
- */
-struct ExpectedChange {
-    size_t row;
-    size_t column;
-    std::string replacement;
-
-    ExpectedChange(const std::smatch& match)
-        : row(stoul(match[1].str())), column(stoul(match[2].str())), replacement(match[3].str()) {}
-};
-
-auto operator==(const ExpectedChange& expected, const minilua::SourceChange& actual) -> bool {
-    return actual.range.start.line + 1 == expected.row &&
-           actual.range.start.column + 1 == expected.column &&
-           actual.replacement == expected.replacement;
-}
-
-auto operator<<(std::ostream& o, const ExpectedChange& self) -> std::ostream& {
-    return o << "ExpectedChange{ " << self.row << ":" << self.column << " " << self.replacement
-             << " }";
-}
-
-static const std::string COMMENT_PREFIX = "-- EXPECT ";
-
-/**
- * Search for comments of the form:
- *
- * ```lua
- * -- EXPECT <something>
- * ```
- */
-auto find_expect_strings(const std::string& source) -> std::vector<std::string> {
-    std::vector<std::string> expect_strings;
-
-    auto start_pos = 0;
-    while (start_pos != std::string::npos) {
-        start_pos = source.find(COMMENT_PREFIX, start_pos);
-        if (start_pos == std::string::npos) {
-            break;
-        }
-
-        start_pos = start_pos + COMMENT_PREFIX.length();
-
-        auto end_pos = source.find('\n', start_pos);
-        if (end_pos == std::string::npos) {
-            end_pos = source.size() - 1;
-        }
-
-        std::string expect_str = source.substr(start_pos, end_pos - start_pos);
-        expect_strings.push_back(expect_str);
-
-        start_pos = end_pos;
-    }
-
-    return expect_strings;
-}
-
-template <typename Iterable, typename Item>
-auto any_of(const Iterable& iterable, const Item& item) -> bool {
-    return std::any_of(
-        iterable.cbegin(), iterable.cend(), [item](const auto& actual) { return item == actual; });
-}
-
-struct BaseTest {
-    std::regex regex;
-
-    BaseTest(std::regex regex) : regex(std::move(regex)) {}
-    virtual ~BaseTest() = default;
-
-    virtual void collect_metadata(const std::string& str) = 0;
-
-    virtual auto expect_source_changes() -> bool { return false; }
-
-    virtual void run(const minilua::EvalResult& result) = 0;
-};
-
-static const std::regex source_change_regex("SOURCE_CHANGE (\\d+):(\\d+) (.*)");
-
-struct SourceChangeTest : BaseTest {
-    std::vector<ExpectedChange> expected_changes;
-
-    SourceChangeTest() : BaseTest(source_change_regex) {}
-    ~SourceChangeTest() override = default;
-
-    void collect_metadata(const std::string& str) override {
-        std::smatch match;
-        if (std::regex_match(str, match, this->regex)) {
-            this->expected_changes.emplace_back(match);
-        }
-    }
-
-    auto expect_source_changes() -> bool override { return !expected_changes.empty(); }
-
-    void run(const minilua::EvalResult& result) override {
-        CAPTURE(expected_changes);
-        // if we found source change tests we require to get source changes
-        if (expected_changes.empty()) {
-            CAPTURE(result.source_change);
-            REQUIRE(!result.source_change.has_value());
-        } else {
-            REQUIRE(result.source_change.has_value());
-            // check that the expected source changes are in the actual source
-            // changes
-            std::vector<minilua::SourceChange> actual_changes;
-            result.source_change.value().visit_all(
-                [&actual_changes](const auto& c) { actual_changes.push_back(c); });
-
-            CAPTURE(actual_changes);
-
-            for (const auto& expected_change : expected_changes) {
-                bool is_in_actual_changes = any_of(actual_changes, expected_change);
-                if (!is_in_actual_changes) {
-                    CAPTURE(expected_change);
-                    FAIL("Could not find expected_change in actual_changes");
-                }
-            }
-        }
-    }
-};
-
-auto get_tests() -> std::vector<std::unique_ptr<BaseTest>> {
-    std::vector<std::unique_ptr<BaseTest>> tests;
-    tests.push_back(std::make_unique<SourceChangeTest>());
-    // TODO add other tests
-
-    return tests;
-}
-
-void test_file(const std::string& file) {
-    std::string program = read_input_from_file(file);
-
-    auto expect_strings = find_expect_strings(program);
-
-    // setup tests
-    auto tests = get_tests();
-    for (auto& test : tests) {
-        for (const auto& str : expect_strings) {
-            test->collect_metadata(str);
-        }
-    }
-
-    // parse
-    minilua::Interpreter interpreter;
-    auto parse_result = interpreter.parse(program);
-    CAPTURE(parse_result.errors);
-    REQUIRE(parse_result);
-
-    // evaluate
-    auto result = interpreter.evaluate();
-
-    // check
-    for (auto& test : tests) {
-        test->run(result);
-    }
-}
-
 TEST_CASE("lua file tests") {
     // collect files to test
     ftw(DIR, ftw_callback, 16); // NOLINT(readability-magic-numbers)
+
+    register_test(new SourceChangeTest());
+    // TODO add other tests
 
     // NOTE: expects to be run from build directory
     for (const auto& file : test_files) {


### PR DESCRIPTION
This creates an initial testing harness for running lua files

- any file in `luaprograms/unit_tests` will automatically be run
- comments of the form `-- EXPECT ...` will be used to check things
  - currently only `-- EXPECT SOURCE_CHANGE <row>:<column> <replacement>` is supported

Future improvements:

- small testing library that wraps things like
  `assert(not pcall(function () assert(false, "message") end))`
  - this probably requires the module system first
- use the line number of the comment automatically
  - this probably needs some parser support
- currently we would also match comments that are not actually comments but for example in a string
