### PR TITLE
Fix scopes

### DIFF
--- a/luaprograms/unit_tests/scopes.lua
+++ b/luaprograms/unit_tests/scopes.lua
@@ -1,0 +1,15 @@
+x = 10
+do
+    local x = x
+    assert(x == 10)
+    x = x + 1
+
+    do
+        local x = x + 1
+        assert(x == 12)
+    end
+
+    assert(x == 11)
+end
+
+assert(x == 10)

--- a/src/details/interpreter.cpp
+++ b/src/details/interpreter.cpp
@@ -576,7 +576,9 @@ auto Interpreter::visit_variable_declaration(ast::VariableDeclaration decl, Env&
             std::visit(
                 overloaded{
                     [this, &env, &value](ast::Identifier ident) {
-                        env.set_local(this->visit_identifier(ident, env), value);
+                        auto ident_str = this->visit_identifier(ident, env);
+                        env.declare_local(ident_str);
+                        env.set_local(ident_str, value);
                     },
                     [](ast::FieldExpression /*node*/) {
                         throw InterpreterException(


### PR DESCRIPTION
Fix scoping of local variables.

`local x = 1` did not create a new local variable if one already existed.

Fixes #141